### PR TITLE
Move from Sminnee to SilverStripe namespace.

### DIFF
--- a/bin/upgrade-code
+++ b/bin/upgrade-code
@@ -9,7 +9,7 @@ if (!defined('PACKAGE_ROOT')) {
 require(PACKAGE_ROOT . 'vendor/autoload.php');
 
 use Symfony\Component\Console\Application;
-use Sminnee\Upgrader\Console as Upgrader;
+use SilverStripe\Upgrader\Console as Upgrader;
 
 $application = new Application();
 $application->setName("SilverStripe Upgrader");

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "sminnee/silverstripe-upgrader",
+  "name": "silverstripe/upgrader",
   "description": "A tool to help upgrade your code to handle API changes in packages you used.",
   "license": "BSD-3-Clause",
   "authors": [
@@ -19,8 +19,8 @@
   },
   "autoload": {
     "psr-4": {
-      "Sminnee\\Upgrader\\": "src/",
-      "Sminnee\\Upgrader\\Tests\\": "tests/"
+      "SilverStripe\\Upgrader\\": "src/",
+      "SilverStripe\\Upgrader\\Tests\\": "tests/"
     }
   }
 }

--- a/src/ChangeDisplayer.php
+++ b/src/ChangeDisplayer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Sminnee\Upgrader;
+namespace SilverStripe\Upgrader;
 
 use Symfony\Component\Console\Output\OutputInterface;
 

--- a/src/CodeChangeSet.php
+++ b/src/CodeChangeSet.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Sminnee\Upgrader;
+namespace SilverStripe\Upgrader;
 
 /**
  * Represents a set of code changes and warnings.

--- a/src/CodeCollection/ChangeApplier.php
+++ b/src/CodeCollection/ChangeApplier.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Sminnee\Upgrader\CodeCollection;
+namespace SilverStripe\Upgrader\CodeCollection;
 
-use Sminnee\Upgrader\CodeChangeSet;
+use SilverStripe\Upgrader\CodeChangeSet;
 
 /**
  * Generic implementation of CollectionInterface::applyChanges

--- a/src/CodeCollection/CollectionInterface.php
+++ b/src/CodeCollection/CollectionInterface.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Sminnee\Upgrader\CodeCollection;
+namespace SilverStripe\Upgrader\CodeCollection;
 
-use Sminnee\Upgrader\CodeChangeSet;
+use SilverStripe\Upgrader\CodeChangeSet;
 
 /**
  * Represents a collection of code files, e.g. a module or project codebase

--- a/src/CodeCollection/DiskCollection.php
+++ b/src/CodeCollection/DiskCollection.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Sminnee\Upgrader\CodeCollection;
+namespace SilverStripe\Upgrader\CodeCollection;
 
-use Sminnee\Upgrader\CodeChangeSet;
+use SilverStripe\Upgrader\CodeChangeSet;
 
 class DiskCollection implements CollectionInterface
 {

--- a/src/CodeCollection/DiskItem.php
+++ b/src/CodeCollection/DiskItem.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Sminnee\Upgrader\CodeCollection;
+namespace SilverStripe\Upgrader\CodeCollection;
 
 /**
  * Represents a simple file on disk.

--- a/src/CodeCollection/ItemInterface.php
+++ b/src/CodeCollection/ItemInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Sminnee\Upgrader\CodeCollection;
+namespace SilverStripe\Upgrader\CodeCollection;
 
 /**
  * Represents a single item in a collection of code files, i.e., one file

--- a/src/Console/UpgradeCommand.php
+++ b/src/Console/UpgradeCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Sminnee\Upgrader\Console;
+namespace SilverStripe\Upgrader\Console;
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -8,10 +8,10 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-use Sminnee\Upgrader\Upgrader;
-use Sminnee\Upgrader\UpgradeSpec;
-use Sminnee\Upgrader\CodeCollection\DiskCollection;
-use Sminnee\Upgrader\ChangeDisplayer;
+use SilverStripe\Upgrader\Upgrader;
+use SilverStripe\Upgrader\UpgradeSpec;
+use SilverStripe\Upgrader\CodeCollection\DiskCollection;
+use SilverStripe\Upgrader\ChangeDisplayer;
 
 class UpgradeCommand extends Command
 {
@@ -54,7 +54,7 @@ class UpgradeCommand extends Command
         // Load the upgrade spec and create an upgrader
         //$spec = UpgradeSpec::loadFromPath($settings['upgrade-spec']);
         $spec = new UpgradeSpec([
-            (new \Sminnee\Upgrader\UpgradeRule\RenameClasses())->withParameters([
+            (new \SilverStripe\Upgrader\UpgradeRule\RenameClasses())->withParameters([
                 'fileExtensions' => [ 'php' ],
                 'namespaceCorrections' => [
                     'SilverStripe\Model',

--- a/src/UpgradeRule/AbstractUpgradeRule.php
+++ b/src/UpgradeRule/AbstractUpgradeRule.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Sminnee\Upgrader\UpgradeRule;
+namespace SilverStripe\Upgrader\UpgradeRule;
 
 use PhpParser\NodeTraverser;
 

--- a/src/UpgradeRule/RenameClasses.php
+++ b/src/UpgradeRule/RenameClasses.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Sminnee\Upgrader\UpgradeRule;
+namespace SilverStripe\Upgrader\UpgradeRule;
 
 use PhpParser\NodeVisitor\NameResolver;
-use Sminnee\Upgrader\Util\MutableSource;
+use SilverStripe\Upgrader\Util\MutableSource;
 
 class RenameClasses extends AbstractUpgradeRule
 {

--- a/src/UpgradeRule/RenameClassesVisitor.php
+++ b/src/UpgradeRule/RenameClassesVisitor.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Sminnee\Upgrader\UpgradeRule;
+namespace SilverStripe\Upgrader\UpgradeRule;
 
 use PhpParser\Node;
 use PhpParser\Node\Stmt;
@@ -11,7 +11,7 @@ use PhpParser\Node\Param;
 use PhpParser\NodeVisitorAbstract;
 use PhpParser\BuilderFactory;
 
-use Sminnee\Upgrader\Util\MutableSource;
+use SilverStripe\Upgrader\Util\MutableSource;
 
 /**
  * PHP-Parser Visitor to handle class renaming upgrade handler for a renamed class

--- a/src/UpgradeSpec.php
+++ b/src/UpgradeSpec.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Sminnee\Upgrader;
+namespace SilverStripe\Upgrader;
 
-use Sminnee\Upgrader\Upgrader\RenameClass;
+use SilverStripe\Upgrader\Upgrader\RenameClass;
 
 class UpgradeSpec
 {

--- a/src/Upgrader.php
+++ b/src/Upgrader.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Sminnee\Upgrader;
+namespace SilverStripe\Upgrader;
 
-use Sminnee\Upgrader\CodeCollection\CollectionInterface;
+use SilverStripe\Upgrader\CodeCollection\CollectionInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**

--- a/src/Util/MutableSource.php
+++ b/src/Util/MutableSource.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Sminnee\Upgrader\Util;
+namespace SilverStripe\Upgrader\Util;
 
 use PhpParser\Lexer;
 use PhpParser\ParserFactory;

--- a/src/Util/MutableString.php
+++ b/src/Util/MutableString.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Sminnee\Upgrader\Util;
+namespace SilverStripe\Upgrader\Util;
 
 use PhpParser\Node;
 

--- a/tests/CodeChangeSetTest.php
+++ b/tests/CodeChangeSetTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Sminnee\Upgrader\Tests;
+namespace SilverStripe\Upgrader\Tests;
 
-use Sminnee\Upgrader\CodeChangeSet;
+use SilverStripe\Upgrader\CodeChangeSet;
 
 class CodeChangeSetTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/CodeCollection/DiskCollectionTest.php
+++ b/tests/CodeCollection/DiskCollectionTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Sminnee\Upgrader\Tests\CodeCollection;
+namespace SilverStripe\Upgrader\Tests\CodeCollection;
 
-use Sminnee\Upgrader\CodeCollection\DiskCollection;
-use Sminnee\Upgrader\CodeCollection\ItemInterface;
+use SilverStripe\Upgrader\CodeCollection\DiskCollection;
+use SilverStripe\Upgrader\CodeCollection\ItemInterface;
 
 class DiskCollectionTest extends \PHPUnit_Framework_TestCase
 {
@@ -13,7 +13,7 @@ class DiskCollectionTest extends \PHPUnit_Framework_TestCase
 
         $names = [];
         foreach ($d->iterateItems() as $item) {
-            $this->assertInstanceOf('Sminnee\Upgrader\CodeCollection\ItemInterface', $item);
+            $this->assertInstanceOf('SilverStripe\Upgrader\CodeCollection\ItemInterface', $item);
             $names[] = $item->getPath();
         }
 

--- a/tests/MockCodeCollection.php
+++ b/tests/MockCodeCollection.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Sminnee\Upgrader\Tests;
+namespace SilverStripe\Upgrader\Tests;
 
-use Sminnee\Upgrader\CodeCollection\CollectionInterface;
-use Sminnee\Upgrader\CodeCollection\ChangeApplier;
+use SilverStripe\Upgrader\CodeCollection\CollectionInterface;
+use SilverStripe\Upgrader\CodeCollection\ChangeApplier;
 
 /**
  * Simple mock upgrade rule to be used in test of other system components

--- a/tests/MockCodeItem.php
+++ b/tests/MockCodeItem.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Sminnee\Upgrader\Tests;
+namespace SilverStripe\Upgrader\Tests;
 
-use Sminnee\Upgrader\CodeCollection\ItemInterface;
+use SilverStripe\Upgrader\CodeCollection\ItemInterface;
 
 /**
  * Simple mock upgrade rule to be used in test of other system components

--- a/tests/MockUpgradeRule.php
+++ b/tests/MockUpgradeRule.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Sminnee\Upgrader\Tests;
+namespace SilverStripe\Upgrader\Tests;
 
-use Sminnee\Upgrader\UpgradeRule\AbstractUpgradeRule;
+use SilverStripe\Upgrader\UpgradeRule\AbstractUpgradeRule;
 
 /**
  * Simple mock upgrade rule to be used in test of other system components

--- a/tests/UpgradeRule/RenameClassesTest.php
+++ b/tests/UpgradeRule/RenameClassesTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Sminnee\Upgrader\Tests\UpgradeRule;
+namespace SilverStripe\Upgrader\Tests\UpgradeRule;
 
-use Sminnee\Upgrader\UpgradeRule\RenameClasses;
+use SilverStripe\Upgrader\UpgradeRule\RenameClasses;
 
 class RenameClassesTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/UpgraderTest.php
+++ b/tests/UpgraderTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Sminnee\Upgrader\Tests;
+namespace SilverStripe\Upgrader\Tests;
 
-use Sminnee\Upgrader\Upgrader;
-use Sminnee\Upgrader\UpgradeSpec;
+use SilverStripe\Upgrader\Upgrader;
+use SilverStripe\Upgrader\UpgradeSpec;
 
 class UpgraderTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Util/MutableSourceTest.php
+++ b/tests/Util/MutableSourceTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Sminnee\Upgrader\Tests\Util;
+namespace SilverStripe\Upgrader\Tests\Util;
 
-use Sminnee\Upgrader\Util\MutableSource;
+use SilverStripe\Upgrader\Util\MutableSource;
 
 class MutableSourceTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Util/MutableStringTest.php
+++ b/tests/Util/MutableStringTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Sminnee\Upgrader\Tests\Util;
+namespace SilverStripe\Upgrader\Tests\Util;
 
-use Sminnee\Upgrader\Util\MutableString;
+use SilverStripe\Upgrader\Util\MutableString;
 
 class MutableStringTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
The Sminnee namespace made sense as a personal project; now that this
has been moved to github.com/silverstripe, it’s best moved to a new
namespace.

It’s good to do this before use of the original namespace is too
entrenched.