### PR TITLE
BUG Error messages showing "" for all "path not found" errors

### DIFF
--- a/src/Console/AddNamespaceCommand.php
+++ b/src/Console/AddNamespaceCommand.php
@@ -67,9 +67,11 @@ class AddNamespaceCommand extends AbstractCommand
 
         // Sanity check input
         if (!is_dir($rootPath)) {
+            $rootPath = $settings['root-dir'];
             throw new \InvalidArgumentException("No silverstripe project found in root-dir \"{$rootPath}\"");
         }
         if (!file_exists($filePath)) {
+            $filePath = $settings['path'];
             throw new \InvalidArgumentException("path \"{$filePath}\" specified doesn't exist");
         }
         // Capture missing double-escape in CLI for namespaces. :)

--- a/src/Console/UpgradeCommand.php
+++ b/src/Console/UpgradeCommand.php
@@ -52,9 +52,11 @@ class UpgradeCommand extends AbstractCommand
 
         // Sanity check input
         if (!is_dir($rootPath)) {
+            $rootPath = $settings['root-dir'];
             throw new \InvalidArgumentException("No silverstripe project found in root-dir \"{$rootPath}\"");
         }
         if (!file_exists($filePath)) {
+            $filePath = $settings['path'];
             throw new \InvalidArgumentException("path \"{$filePath}\" specified doesn't exist");
         }
         // Find module name


### PR DESCRIPTION
Fixes #6

Because I'm using "realpath" to cleanup paths, if they are non-existent they get turned into empty strings.