### PR TITLE
API Better logic applied to rewrite of strings

### DIFF
--- a/src/UpgradeRule/ParentConnector.php
+++ b/src/UpgradeRule/ParentConnector.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace SilverStripe\Upgrader\UpgradeRule;
+
+use PhpParser\Node;
+use PhpParser\NodeVisitorAbstract;
+
+/**
+ * Ensures that each node has a parent property
+ *
+ * Credit to @nikic {@link https://github.com/nikic/PHP-Parser/issues/238}
+ */
+class ParentConnector extends NodeVisitorAbstract
+{
+    /**
+     * @var Node[] List of nodes in the current stack
+     */
+    protected $stack;
+
+    /**
+     * @param array $nodes
+     */
+    public function beginTraverse(array $nodes)
+    {
+        $this->stack = [];
+    }
+
+    public function enterNode(Node $node)
+    {
+        if (!empty($this->stack)) {
+            $node->setAttribute('parent', end($this->stack));
+        }
+
+        $this->stack[] = $node;
+    }
+
+    public function leaveNode(Node $node)
+    {
+        array_pop($this->stack);
+    }
+}

--- a/src/UpgradeRule/RenameClasses.php
+++ b/src/UpgradeRule/RenameClasses.php
@@ -29,9 +29,13 @@ class RenameClasses extends AbstractUpgradeRule
             }
         }
 
+        $mappings = isset($this->parameters['mappings']) ? $this->parameters['mappings'] : [];
+        $skipConfig = isset($this->parameters['skipConfigs']) ? $this->parameters['skipConfigs'] : [];
+
         $this->transformWithVisitors($source->getAst(), [
-            new NameResolver(),
-            new RenameClassesVisitor($source, $this->parameters['mappings'], $namespaceCorrections),
+            new NameResolver(), // Add FQN for class references
+            new ParentConnector(), // Link child nodes to parents
+            new RenameClassesVisitor($source, $mappings, $namespaceCorrections, $skipConfig),
         ]);
 
         return $source->getModifiedString();

--- a/src/Util/MutableSource.php
+++ b/src/Util/MutableSource.php
@@ -37,7 +37,9 @@ class MutableSource
         $this->source = new MutableString($source);
         $this->prettyPrinter = new PrettyPrinter\Standard();
 
-        $lexer = new Lexer\Emulative(['usedAttributes' => ['startFilePos', 'endFilePos', 'startLine', 'endLine']]);
+        $lexer = new Lexer\Emulative([
+            'usedAttributes' => ['comments', 'startFilePos', 'endFilePos', 'startLine', 'endLine']
+        ]);
         $parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP5, $lexer);
         $this->ast = $parser->parse($source);
     }

--- a/tests/UpgradeRule/RenameClassesTest.php
+++ b/tests/UpgradeRule/RenameClassesTest.php
@@ -11,6 +11,7 @@ class RenameClassesTest extends \PHPUnit_Framework_TestCase
     /**
      * @param string $file
      * @return array
+     * @throws \Exception
      */
     protected function getFixtures($file)
     {
@@ -18,6 +19,9 @@ class RenameClassesTest extends \PHPUnit_Framework_TestCase
         $fixture = file_get_contents(__DIR__ .'/fixtures/'.$file);
         list($parameters, $input, $output) = preg_split('/------+/', $fixture, 3);
         $parameters = json_decode($parameters, true);
+        if (!$parameters) {
+            throw new \Exception(json_last_error_msg());
+        }
         $input = trim($input);
         $output = trim($output);
 
@@ -32,6 +36,7 @@ class RenameClassesTest extends \PHPUnit_Framework_TestCase
         return [
             ['rename-classes.testfixture'],
             ['rename-simple.testfixture'],
+            ['rename-strings.testfixture'],
         ];
     }
 

--- a/tests/UpgradeRule/fixtures/rename-classes.testfixture
+++ b/tests/UpgradeRule/fixtures/rename-classes.testfixture
@@ -84,7 +84,7 @@ class ExampleSubclass extends ExampleField implements RenamedInterface
         if   ($baz instanceof RenamedInterface) {
             return true;
         }
-        if(interface_exists('SilverStripe\Fields\RenamedInterface')) return true;
+        if(interface_exists('SilverStripe\\Fields\\RenamedInterface')) return true;
 
         try {
             echo 'hello';

--- a/tests/UpgradeRule/fixtures/rename-strings.testfixture
+++ b/tests/UpgradeRule/fixtures/rename-strings.testfixture
@@ -1,0 +1,76 @@
+{
+    "mappings": {
+        "SS_MyClass": "Namespace\\MyClass",
+        "SS_AnotherClass": "AnotherClass"
+    },
+    "skipConfigs": [
+        "db",
+        "casting"
+    ]
+}
+------
+<?php
+
+/**
+ * Rewrite this class
+ */
+class ExampleSubclass extends ExampleField implements ExampleInterface
+{
+    private static $db = [
+        'SS_MyClass' => 'SS_MyClass'
+    ];
+
+    const CONSTVAL = 'SS_MyClass';
+
+    private static $casting = [
+        "SS_MyClass" => "SS_MyClass"
+    ];
+
+    private static $another_config = 'SS_MyClass';
+
+    private static $array_config = [
+        'SS_MyClass' => 'SS_AnotherClass',
+    ];
+
+    function construct() {
+        $args = array(
+            'SS_MyClass' => 'SS_MyClass',
+        );
+        /** @skipUpgrade */
+        $dont = 'SS_MyClass';
+        return Injector::inst()->createWithArgs('SS_MyClass', $args);
+    }
+}
+------
+<?php
+
+/**
+ * Rewrite this class
+ */
+class ExampleSubclass extends ExampleField implements ExampleInterface
+{
+    private static $db = [
+        'SS_MyClass' => 'SS_MyClass'
+    ];
+
+    const CONSTVAL = 'SS_MyClass';
+
+    private static $casting = [
+        "SS_MyClass" => "SS_MyClass"
+    ];
+
+    private static $another_config = 'Namespace\\MyClass';
+
+    private static $array_config = [
+        'SS_MyClass' => 'AnotherClass',
+    ];
+
+    function construct() {
+        $args = array(
+            'SS_MyClass' => 'Namespace\\MyClass',
+        );
+        /** @skipUpgrade */
+        $dont = 'SS_MyClass';
+        return Injector::inst()->createWithArgs('Namespace\\MyClass', $args);
+    }
+}


### PR DESCRIPTION
Ability to specify a list of config names to blacklist rewriting
Added ability to specify `@skipUpgrade` on a block to disable rewriting
Disable rewriting for array keys and consts
Fixes #1

I have run this on https://github.com/open-sausages/silverstripe-framework/tree/namespace/orm and confirmed that it introduces no changes. I.e. none of the manual fixes were re-broken.

See https://github.com/open-sausages/silverstripe-framework/commit/e2c43a7b458741201e0fa06eeff735bb533510fe for extra config required.