### PR TITLE
BUG Fix crash on null substitution string 'kind'

### DIFF
--- a/src/UpgradeRule/RenameClassesVisitor.php
+++ b/src/UpgradeRule/RenameClassesVisitor.php
@@ -74,7 +74,7 @@ class RenameClassesVisitor extends NodeVisitorAbstract
             }
             // Substitute new node, keep quote type (double / single)
             $replacementNode = new Scalar\String_($replacement, [
-                'kind' => $stringNode->getAttribute('kind')
+                'kind' => $stringNode->getAttribute('kind', Scalar\String_::KIND_SINGLE_QUOTED)
             ]);
             $this->source->replaceNode($stringNode, $replacementNode);
         }


### PR DESCRIPTION
Occasionally would get "unknown string kind" if the source string kind is empty, for whatever reason. Default to single quoted strings in this case.