### PR TITLE
Remove JS key replacement for rule=lang

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,6 @@ as these are not ambiguous, and the upgrader can safely update these references.
 
 You can also upgrade all localisation strings in the below files:
 
- - keys in lang/src/*.js
- - keys in lang/src/*.json
  - keys in lang/*.yml
  - _t() method keys in all .php files
  

--- a/src/Console/UpgradeCommand.php
+++ b/src/Console/UpgradeCommand.php
@@ -2,7 +2,6 @@
 
 namespace SilverStripe\Upgrader\Console;
 
-use SilverStripe\Upgrader\UpgradeRule\JS\RenameJSLangKeys;
 use SilverStripe\Upgrader\UpgradeRule\PHP\RenameClasses;
 use SilverStripe\Upgrader\UpgradeRule\PHP\RenameTranslateKeys;
 use SilverStripe\Upgrader\UpgradeRule\YML\RenameYMLLangKeys;
@@ -101,7 +100,6 @@ class UpgradeCommand extends AbstractCommand
         if (in_array('lang', $rules)) {
             $spec->addRule((new RenameTranslateKeys())->withParameters($config));
             $spec->addRule((new RenameYMLLangKeys())->withParameters($config));
-            $spec->addRule((new RenameJSLangKeys())->withParameters($config));
         }
 
         // Create upgrader with this spec


### PR DESCRIPTION
Per team discussion on Slack, we won't be enforcing FQCN translation keys in JS. This change keeps the upgrade rule for replacing JS keys, in case we want to add it back and/or refactor it later, but removes it as an option from the public API.