### PR TITLE
ENHANCEMENT: Upgrade i18n keys in templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ You can also upgrade all localisation strings in the below files:
 
  - keys in lang/*.yml
  - _t() method keys in all .php files
+ - <%t and <% _t() method keys in all .ss files
  
 You can run the upgrader on these keys with the below command:
 

--- a/src/Console/UpgradeCommand.php
+++ b/src/Console/UpgradeCommand.php
@@ -6,6 +6,7 @@ use SilverStripe\Upgrader\UpgradeRule\PHP\RenameClasses;
 use SilverStripe\Upgrader\UpgradeRule\PHP\RenameTranslateKeys;
 use SilverStripe\Upgrader\UpgradeRule\YML\RenameYMLLangKeys;
 use SilverStripe\Upgrader\UpgradeRule\YML\UpdateConfigClasses;
+use SilverStripe\Upgrader\UpgradeRule\SS\RenameTemplateLangKeys;
 use SilverStripe\Upgrader\Util\ConfigFile;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
@@ -100,6 +101,7 @@ class UpgradeCommand extends AbstractCommand
         if (in_array('lang', $rules)) {
             $spec->addRule((new RenameTranslateKeys())->withParameters($config));
             $spec->addRule((new RenameYMLLangKeys())->withParameters($config));
+            $spec->addRule((new RenameTemplateLangKeys())->withParameters($config));
         }
 
         // Create upgrader with this spec

--- a/src/UpgradeRule/SS/RenameTemplateLangKeys.php
+++ b/src/UpgradeRule/SS/RenameTemplateLangKeys.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace SilverStripe\Upgrader\UpgradeRule\SS;
+
+use SilverStripe\Upgrader\CodeCollection\CodeChangeSet;
+use SilverStripe\Upgrader\CodeCollection\ItemInterface;
+
+/**
+ * Renames template locale keys
+ */
+class RenameTemplateLangKeys extends TemplateUpgradeRule
+{
+    /**
+     * Upgrades the contents of the given file
+     * Returns string containing the new code.
+     *
+     * @param string $contents
+     * @param ItemInterface $file
+     * @param \SilverStripe\Upgrader\CodeCollection\CodeChangeSet $changeset Changeset to add warnings to
+     * @return string
+     */
+    public function upgradeFile($contents, ItemInterface $file, CodeChangeSet $changeset)
+    {
+        if (!$this->appliesTo($file)) {
+            return $contents;
+        }
+
+        $patterns = [
+            '/_t\s*\(\s*(?:\'|")([A-Za-z_]+)\./',
+            '/<%t\s*(?:\'|")?([A-Za-z_]+)\./'
+        ];
+        $searches = [];
+        $replacements = [];
+        $mappings = $this->parameters['mappings'];
+
+        foreach ($patterns as $pattern) {
+            preg_match_all($pattern, $contents, $matches, PREG_SET_ORDER);
+            if ($matches) {
+                foreach ($matches as $m) {
+                    list($tag, $key) = $m;
+                    if (!isset($mappings[$key])) {
+                        continue;
+                    }
+
+                    $newKey = str_replace('\\', '\\\\\\\\', $mappings[$key]);
+                    $newTag = preg_replace('/[A-Za-z_]+\./', $newKey . '.', $tag);
+                    $searches[] = $tag;
+                    $replacements[] = $newTag;
+                }
+            }
+        }
+
+        return str_replace($searches, $replacements, $contents);
+    }
+}

--- a/src/UpgradeRule/SS/TemplateUpgradeRule.php
+++ b/src/UpgradeRule/SS/TemplateUpgradeRule.php
@@ -1,0 +1,20 @@
+<?php
+namespace SilverStripe\Upgrader\UpgradeRule\SS;
+
+use SilverStripe\Upgrader\CodeCollection\ItemInterface;
+use SilverStripe\Upgrader\UpgradeRule\AbstractRule;
+
+abstract class TemplateUpgradeRule extends AbstractRule
+{
+    /**
+     * Returns true if this upgrade rule applies to the given file
+     * Checks fileExtensions parameters
+     *
+     * @param ItemInterface $file
+     * @return bool
+     */
+    public function appliesTo(ItemInterface $file)
+    {
+        return preg_match('#\.ss$#', $file->getFullPath());
+    }
+}

--- a/src/UpgradeRule/YML/YMLUpgradeRule.php
+++ b/src/UpgradeRule/YML/YMLUpgradeRule.php
@@ -8,7 +8,7 @@ use SilverStripe\Upgrader\UpgradeRule\AbstractRule;
 abstract class YMLUpgradeRule extends AbstractRule
 {
     /**
-     * Returns true if this upgrad rule applies to the given file
+     * Returns true if this upgrade rule applies to the given file
      * Checks fileExtensions parameters
      *
      * @param ItemInterface $file

--- a/tests/UpgradeRule/SS/RenameTemplateLangKeysTest.php
+++ b/tests/UpgradeRule/SS/RenameTemplateLangKeysTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace SilverStripe\Upgrader\Tests\UpgradeRule\SS;
+
+use PHPUnit_Framework_TestCase;
+use SilverStripe\Upgrader\CodeCollection\CodeChangeSet;
+use SilverStripe\Upgrader\Tests\FixtureLoader;
+use SilverStripe\Upgrader\Tests\MockCodeCollection;
+use SilverStripe\Upgrader\UpgradeRule\SS\RenameTemplateLangKeys;
+
+class RenameTemplateLangKeysTest extends PHPUnit_Framework_TestCase
+{
+    use FixtureLoader;
+
+    public function testUpgradeTemplateLangKeys()
+    {
+        list($parameters, $input, $output)
+            = $this->loadFixture(__DIR__ .'/fixtures/rename-i18n-keys.testfixture');
+        $updater = (new RenameTemplateLangKeys())
+            ->withParameters($parameters);
+        $path = 'mysite/templates/Test.ss';
+
+        // Build mock collection
+        $code = new MockCodeCollection([
+            $path => $input
+        ]);
+        $file = $code->itemByPath($path);
+        $changeset = new CodeChangeSet();
+
+        $generated = $updater->upgradeFile($input, $file, $changeset);
+
+        $this->assertFalse($changeset->hasWarnings($path));
+        $this->assertEquals($output, $generated);
+    }
+}

--- a/tests/UpgradeRule/SS/fixtures/rename-i18n-keys.testfixture
+++ b/tests/UpgradeRule/SS/fixtures/rename-i18n-keys.testfixture
@@ -1,0 +1,42 @@
+{
+    "mappings": {
+        "SS_MyClass": "Namespace\\MyClass",
+        "SSAnotherClass": "Another\\Class\\Namespace"
+    }
+}
+------
+<div>
+<% if $SomeVar.SomeProp %>
+    <a href="$SomeVar.SomeProp" target="_test" class="button" data-icon="preview">
+    <% _t('SS_MyClass.Test1', 'Test1') %> &raquo;
+    <% _t('SSAnotherClass.Test1', 'Test1') %> &raquo;
+    </a>
+    <h2><%t SSAnotherClass.Test2 'This is a test' %>
+    <div>
+        <small><%t 'SS_MyClass.Test3' 'Another test' %>
+        <div><%t NotMapped.Nothing 'This does not get upgraded' %></div>
+    </div>
+<% end_if %>
+    <ul>
+        <li><% _t('SS_MyClass.Test2', 'Test2') %> &raquo;</li>
+        <li><% _t('NotMapped.Nothing', 'Nothing') %></li>
+    </ul>
+</div>
+------
+<div>
+<% if $SomeVar.SomeProp %>
+    <a href="$SomeVar.SomeProp" target="_test" class="button" data-icon="preview">
+    <% _t('Namespace\\MyClass.Test1', 'Test1') %> &raquo;
+    <% _t('Another\\Class\\Namespace.Test1', 'Test1') %> &raquo;
+    </a>
+    <h2><%t Another\\Class\\Namespace.Test2 'This is a test' %>
+    <div>
+        <small><%t 'Namespace\\MyClass.Test3' 'Another test' %>
+        <div><%t NotMapped.Nothing 'This does not get upgraded' %></div>
+    </div>
+<% end_if %>
+    <ul>
+        <li><% _t('Namespace\\MyClass.Test2', 'Test2') %> &raquo;</li>
+        <li><% _t('NotMapped.Nothing', 'Nothing') %></li>
+    </ul>
+</div>


### PR DESCRIPTION
When `--rule=lang` is enabled, the upgrader now parses `.ss` files for `<%t` tags in addition to PHP files.