### PR TITLE
Adding PSR-4 option for  command

### DIFF
--- a/docs/en/add-namespace.md
+++ b/docs/en/add-namespace.md
@@ -3,7 +3,7 @@
 You can run the below to add namespace to any class
 
 ```bash
-upgrade-code add-namespace <namespace> <filepath> [--root-dir=<dir>] [--write] [--recursive] [-r] [-vvv]
+upgrade-code add-namespace <namespace> <filepath> [--root-dir=<dir>] [--write] [--recursive] [-r] [-p] [-vvv]
 ```
 
 E.g.
@@ -14,8 +14,10 @@ upgrade-code add-namespace "My\Namespace" ./mysite/code/SomeCode.php --write -vv
 
 * Make sure you run this in your project root, or set the root with --root-dir.
 * Note that it's important to either quote or double-escape slashes in the namespace.
-* If you want to just do a dry-run, skip the `--write` and `--upgrade-spec` params.
+* If you want to just do a dry-run, skip the `--write` param.
 * If you have multiple namespace levels you can add the `--recursive` or `-r` param to also update those levels.
+* If your filepath follows PSR-4 you can add the `--psr4` or `-p` param with the recursive param to auto-complete 
+namespaces in child directories.
 
 This will namespace the class file SomeCode.php, and add the mapping to the `./.upgrader.yml` file in your project.
 

--- a/src/Console/AddNamespaceCommand.php
+++ b/src/Console/AddNamespaceCommand.php
@@ -34,6 +34,12 @@ class AddNamespaceCommand extends AbstractCommand
                     InputOption::VALUE_NONE,
                     'Set to recursively namespace'
                 ),
+                new InputOption(
+                    'psr4',
+                    'p',
+                    InputOption::VALUE_NONE,
+                    'When used with the recursive option, assume directories and namespaces are PSR-4 compliant'
+                ),
                 $this->getRootInputOption(),
                 $this->getWriteInputOption()
             ]);
@@ -50,6 +56,7 @@ class AddNamespaceCommand extends AbstractCommand
         $writeChanges = !empty($settings['write']);
         $namespace = $settings['namespace'];
         $recursive = !empty($settings['recursive']);
+        $psr4 = !empty($settings['psr4']);
 
         // Capture missing double-escape in CLI for namespaces. :)
         if (stripos($namespace, "\\") === false) {
@@ -76,6 +83,7 @@ class AddNamespaceCommand extends AbstractCommand
                         'Page_Controller',
                         'PageController',
                     ],
+                    'psr4' => $psr4,
                 ],
             ],
         ];

--- a/src/UpgradeRule/PHP/AddNamespaceRule.php
+++ b/src/UpgradeRule/PHP/AddNamespaceRule.php
@@ -59,6 +59,13 @@ class AddNamespaceRule extends PHPUpgradeRule
     {
         $modification = $this->getModificationForFile($file);
         if ($modification && isset($modification['namespace'])) {
+            if ($modification['psr4']) {
+                $namespaceParts = explode(DIRECTORY_SEPARATOR, $file->getPath());
+                array_pop($namespaceParts);
+                if (!empty($namespaceParts)) {
+                    return $modification['namespace'] . '\\' . implode('\\', $namespaceParts);
+                }
+            }
             return $modification['namespace'];
         }
         return null;


### PR DESCRIPTION
I came across this when upgrading a module that adhered to PSR-4 in the source root. I figured it would be quite a bit easier to be able to run this just once for all files as the namespace can easily be determined from the file path.

I also removed the reference to `--upgrade-spec` in the docs as that never seemed to exist.