### PR TITLE
:bug: Rewrite 1.1 and 1.0 recipe version to 4

### DIFF
--- a/src/Composer/Rules/Rebuild.php
+++ b/src/Composer/Rules/Rebuild.php
@@ -77,18 +77,17 @@ class Rebuild implements DependencyUpgradeRule
     /**
      * Setter for the Recipe Core Targeted version.
      * @param string $value
+     * @return void
      */
     public function setRecipeCoreTarget(string $value):void
     {
-        if (
-            Comparator::greaterThanOrEqualTo($value, '4.0') &&
+        if (Comparator::greaterThanOrEqualTo($value, '4.0') &&
             Comparator::lessThan($value, '4.2')) {
             // If the value is between 4.0 and 4.2, convert it to the the 1.x equivalent.
             // This is necessary because recipe-core and recipe-cms were originally release with a 1.0 version and got
             // renumbered to 4.x with 4.2
             $value = preg_replace('/^4/', '1', $value);
-        } else if (
-            // Rewrite any version constraint above 1.2 but below 2 to 4.x
+        } elseif (// Rewrite any version constraint above 1.2 but below 2 to 4.x
             Comparator::greaterThanOrEqualTo($value, '1.2') &&
             Comparator::lessThan($value, '2.0')) {
             $value = preg_replace('/^1/', '4', $value);

--- a/tests/Composer/Rules/RebuildTest.php
+++ b/tests/Composer/Rules/RebuildTest.php
@@ -108,8 +108,8 @@ class RebuildTest extends TestCase
         $dependencies = $rule->switchToRecipeCore($this->dependencies);
 
         // Test a package that has recipe-core and recipe-cms explicitly define
-        $composer->require(SilverstripePackageInfo::RECIPE_CORE, '^1.1', $schema->getBasePath());
-        $composer->require(SilverstripePackageInfo::RECIPE_CMS, '^1.1', $schema->getBasePath());
+        $composer->require(SilverstripePackageInfo::RECIPE_CORE, '^4.2', $schema->getBasePath());
+        $composer->require(SilverstripePackageInfo::RECIPE_CMS, '^4.2', $schema->getBasePath());
 
         $rule->findRecipeEquivalence($dependencies, $composer, $schema);
 
@@ -145,5 +145,19 @@ class RebuildTest extends TestCase
         $this->assertArrayNotHasKey(SilverstripePackageInfo::FRAMEWORK, $require);
         $this->assertArrayNotHasKey(SilverstripePackageInfo::CMS, $require);
         $this->assertArrayNotHasKey('silverstripe/contentreview', $require);
+    }
+
+    public function testRecipeCoreTarget()
+    {
+        $rule = new Rebuild('4.1.1');
+        $this->assertEquals('1.1.1', $rule->getRecipeCoreTarget());
+        $rule->setRecipeCoreTarget('4.2.0');
+        $this->assertEquals('4.2.0', $rule->getRecipeCoreTarget());
+        $rule->setRecipeCoreTarget('4.0.0');
+        $this->assertEquals('1.0.0', $rule->getRecipeCoreTarget());
+        $rule->setRecipeCoreTarget('1.0.1');
+        $this->assertEquals('1.0.1', $rule->getRecipeCoreTarget());
+        $rule->setRecipeCoreTarget('1.2.0');
+        $this->assertEquals('4.2.0', $rule->getRecipeCoreTarget());
     }
 }


### PR DESCRIPTION
Get recipe version 4.0 and 4.1 rewritten to 1.0/1.1. I've also implemented the reverse logic for version that match ^1.2 ... recipe 1.2 will be rewritten to 4.2.

I've also fix a unit test bug that was failing because recipe-collaboration now targets recipe-core `4.2.0-beta` ... yes, having your unit test rely on the dependency of package is dodgy.

# Parent issue
* #123