### PR TITLE
Get travis to deploy PHAR on release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ matrix:
       env:
         - SYMFONY="3.2.*"
     - php: 7.2
+      env:
+        - RELEASE=1
 
 sudo: false
 
@@ -36,3 +38,27 @@ before_script:
 script:
   - vendor/bin/phpunit --color tests
   - if [[ $LINT_TEST ]]; then composer run-script lint; fi
+
+before_deploy:
+  - if [[ ! -f ./release/upgrade-code.phar ]]; then php build.php; fi
+  - mkdir -p ./release
+  - if [[ -f ./upgrade-code.phar ]]; then mv upgrade-code.phar ./release/; fi
+
+deploy:
+  - provider: releases
+    skip_cleanup: true
+    api_key: $GITHUB_API_TOKEN
+    file: release/upgrade-code.phar
+    on:
+      tags: true
+      repo: silverstripe/silverstripe-upgrader
+      condition: -n $RELEASE
+  - provider: pages
+    skip_cleanup: true
+    keep-history: true
+    github-token: $GITHUB_API_TOKEN
+    local-dir: release
+    on:
+      tags: true
+      repo: silverstripe/silverstripe-upgrader
+      condition: -n $RELEASE

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,8 @@ before_script:
 
 # Install composer dependencies
   - composer validate
-  - if [[ $SYMFONY ]]; then composer require symfony/console:$SYMFONY symfony/process:$SYMFONY symfony/filesystem:$SYMFONY; fi
-  - composer install
+  - if [[ $SYMFONY ]]; then composer require symfony/console:$SYMFONY symfony/process:$SYMFONY symfony/filesystem:$SYMFONY --no-update; fi
+  - composer install --prefer-source --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
   - composer global require squizlabs/php_codesniffer:^3 --prefer-dist --no-interaction --no-progress --no-suggest -o
 
 script:

--- a/build.php
+++ b/build.php
@@ -51,6 +51,7 @@ $fs->remove(BUILD_FOLDER);
 $process = new Process($compiledPath);
 try {
     $process->mustRun();
+    echo "Phar built to: $compiledPath \n";
 } catch (ProcessFailedException $ex) {
     echo "The generated executable is broken.\nDO NOT PUBLISH!!!\n\n";
     echo $ex->getMessage();


### PR DESCRIPTION
Simple automated publishing of phar on release of tag to both GH Releases and to gh-pages

This PR:
- Adds output on successful build
- Improves composer install steps to reduce repeated dependency resolutions and bring this repo inline with our approach across others
- Adds deployments to GH Releases & GH Pages

This PR makes use of the existing `$GITHUB_API_TOKEN` stored against our repo; please note that token needs `public_repo` access scope for deploys to work correctly. If that scope is missing the token will need updating/replacing