### PR TITLE
MINOR Escape path when running composer validate.

### DIFF
--- a/src/Composer/ComposerExec.php
+++ b/src/Composer/ComposerExec.php
@@ -215,7 +215,7 @@ EOF
      */
     public function validate(string $path = '', bool $throwException = false): bool
     {
-        $process = $this->run('validate ' . $path);
+        $process = $this->run(sprintf('validate %s', escapeshellarg($path)));
 
         if ($throwException && !$process->isSuccessful()) {
             throw new RuntimeException($process->getErrorOutput());

--- a/tests/Composer/ComposerExecTest.php
+++ b/tests/Composer/ComposerExecTest.php
@@ -71,6 +71,11 @@ class ComposerExecTest extends TestCase
             'Validating a valid composer file should return true'
         );
 
+        $this->assertTrue(
+            $composer->validate(__DIR__ . '/fixture/!@#$%^&* crazy folder name/composer.json'),
+            'Validating should work even if the path contains spaces.'
+        );
+
         $this->assertFalse(
             $composer->validate(__DIR__ . '/fixture/invalid-composer.json'),
             'Validating an invalid composer file should return false'

--- a/tests/Composer/fixture/!@#$%^&* crazy folder name/composer.json
+++ b/tests/Composer/fixture/!@#$%^&* crazy folder name/composer.json
@@ -1,0 +1,46 @@
+{
+    "name": "silverstripe/upgrader",
+    "description": "A tool to help upgrade your code to handle API changes in packages you used.",
+    "license": "BSD-3-Clause",
+    "authors": [
+        {
+            "name": "Sam Minnee",
+            "email": "sam@silverstripe.com"
+        }
+    ],
+    "require": {
+        "php": "^7",
+        "nikic/php-parser": "^3.1",
+        "symfony/console": "^3.2",
+        "symfony/yaml": "^3.2",
+        "phpspec/php-diff": "^1",
+        "phpstan/phpstan": "^0.10",
+        "phpstan/phpstan-php-parser": "^0.10",
+        "m1/env": "^2.1",
+        "ext-json": "*"
+    },
+    "bin": [
+        "bin/upgrade-code"
+    ],
+    "require-dev": {
+        "phpunit/phpunit": "^7",
+        "mikey179/vfsStream": "^1.6"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.1.x-dev"
+        }
+    },
+    "autoload": {
+        "psr-4": {
+            "SilverStripe\\Upgrader\\": "src/",
+            "SilverStripe\\Upgrader\\Tests\\": "tests/"
+        }
+    },
+    "scripts": {
+        "lint": "phpcs src/ tests/",
+        "lint-clean": "phpcbf src/ tests/"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}


### PR DESCRIPTION
If your path contains spaces, composer validate will fail because the path is not escape.