### PR TITLE
Fixes build failure and other minor improvement

### DIFF
--- a/src/Composer/ComposerExec.php
+++ b/src/Composer/ComposerExec.php
@@ -180,7 +180,7 @@ EOF
         }
 
         // Output errors.
-        if ($process->isSuccessful() && !$this->suppressErrors && $this->out) {
+        if (!$process->isSuccessful() && !$this->suppressErrors && $this->out) {
             $out = $this->out instanceof ConsoleOutputInterface ?
                 $this->out->getErrorOutput() :
                 $this->out;
@@ -258,7 +258,7 @@ EOF
      */
     public function require(
         string $package,
-        string $constraint = '',
+        string $constraint = '*',
         string $workingDir = '',
         bool   $showFeedback = false
     ):void {
@@ -279,6 +279,7 @@ EOF
                 '--working-dir' => $workingDir,
                 '--prefer-stable' => '',
                 '--ignore-platform-reqs' => '',
+                '--no-plugins' => ''
             ],
             $showFeedback
         );
@@ -299,12 +300,14 @@ EOF
      * @param  string  $workingDir   Path to the directory containing the `composer.json`. Defaults to this instance's
      *    $workingDir.
      * @param  boolean $showFeedback Write out some information about what is going on.
+     * @param  boolean $allowPlugins Whatever we let composer plugins run. Defaults to false.
      * @throws RuntimeException If update fails.
      * @return void
      */
     public function update(
         string $workingDir = '',
-        bool   $showFeedback = false
+        bool   $showFeedback = false,
+        bool   $allowPlugins = false
     ): void {
         $showFeedback = $showFeedback && $this->out;
 
@@ -312,15 +315,17 @@ EOF
             $this->out->write(' Trying to install dependencies ');
         }
 
-        $process = $this->run(
-            "update",
-            [
-                '--working-dir' => $workingDir,
-                '--prefer-stable' => '',
-                '--ignore-platform-reqs' => '',
-            ],
-            $showFeedback
-        );
+        $options = [
+            '--working-dir' => $workingDir,
+            '--prefer-stable' => '',
+            '--ignore-platform-reqs' => '',
+        ];
+
+        if (!$allowPlugins) {
+            $options['--no-plugins'] = '';
+        }
+
+        $process = $this->run("update", $options, $showFeedback);
 
         if ($process->isSuccessful()) {
             if ($showFeedback) {
@@ -347,6 +352,7 @@ EOF
             'remove ' . $package,
             [
                 '--working-dir' => $workingDir,
+                '--no-plugins' => ''
             ]
         );
     }
@@ -361,7 +367,7 @@ EOF
     {
         $this->run(
             'install',
-            ['--working-dir' => $workingDir, '--ignore-platform-reqs' => '']
+            ['--working-dir' => $workingDir, '--ignore-platform-reqs' => '', '--no-plugins' => '']
         );
     }
 

--- a/src/Composer/Recipe.php
+++ b/src/Composer/Recipe.php
@@ -101,6 +101,9 @@ class Recipe
      */
     public function subsetOf(array $dependencies, array $tree = []): array
     {
+        // If our recipe is already installed, let's return all the packages that can be remove thanks to it.
+        $recipeInDependency = in_array($this->getName(), $dependencies);
+
         $tree = $tree ?: $this->buildDependencyTree();
 
         $intersection = [];
@@ -121,12 +124,16 @@ class Recipe
                     $intersection[] = $branch;
                     $intersection = array_merge($intersection, $subSetIntersection);
                 } else {
+                    if (!$recipeInDependency) {
+                        // Dependency was not met
+                        return [];
+                    }
+                }
+            } else {
+                if (!$recipeInDependency) {
                     // Dependency was not met
                     return [];
                 }
-            } else {
-                // Dependency was not met
-                return [];
             }
         }
 

--- a/src/Composer/Recipe.php
+++ b/src/Composer/Recipe.php
@@ -123,17 +123,13 @@ class Recipe
                 if ($subSetIntersection) {
                     $intersection[] = $branch;
                     $intersection = array_merge($intersection, $subSetIntersection);
-                } else {
-                    if (!$recipeInDependency) {
-                        // Dependency was not met
-                        return [];
-                    }
-                }
-            } else {
-                if (!$recipeInDependency) {
+                } elseif (!$recipeInDependency) {
                     // Dependency was not met
                     return [];
                 }
+            } elseif (!$recipeInDependency) {
+                // Dependency was not met
+                return [];
             }
         }
 

--- a/src/Composer/Rules/Rebuild.php
+++ b/src/Composer/Rules/Rebuild.php
@@ -274,7 +274,7 @@ class Rebuild implements DependencyUpgradeRule
 
         foreach (Recipe::getKnownRecipes() as $recipe) {
             $recipeName = $recipe->getName();
-
+            
             $subset = $recipe->subsetOf($installedDependencies);
             if ($subset) {
                 $toInstall[] = $recipeName;
@@ -291,6 +291,8 @@ class Rebuild implements DependencyUpgradeRule
         // Clean up our arrays and make sure there's nothing in $toInstall that's also in $toRemove.
         $toRemove = array_unique($toRemove);
         $toInstall = array_diff($toInstall, $toRemove);
+        // Don't try to install the dependency if it's already installed
+        $toInstall = array_diff($toInstall, $explicitDependencies);
 
         // Start by removing packages
         foreach ($toRemove as $packageName) {

--- a/src/Composer/Rules/Rebuild.php
+++ b/src/Composer/Rules/Rebuild.php
@@ -301,7 +301,7 @@ class Rebuild implements DependencyUpgradeRule
         }
 
         foreach ($toInstall as $packageName) {
-            $composer->require($packageName, '', $schemaFile->getBasePath(), true);
+            $composer->require($packageName, '*', $schemaFile->getBasePath(), true);
         }
 
         if (in_array(SilverstripePackageInfo::RECIPE_CORE, $toRemove)) {

--- a/src/Console/RecomposeCommand.php
+++ b/src/Console/RecomposeCommand.php
@@ -164,10 +164,10 @@ class RecomposeCommand extends AbstractCommand implements AutomatedCommand
 
             $console->title('Trying to install new dependencies');
             try {
-                $composer->update('', true);
-                // We need to run another update because our recipes will update the `extra` object in our
+                // We need to run the update twice because our recipes will update the `extra` object in our
                 // composer.json which invalidates our composer.lock
-                $composer->update('', false);
+                $composer->update('', false, true);
+                $composer->update('', false, true);
                 $console->success('Dependencies installed successfully.');
             } catch (RuntimeException $ex) {
                 $message =

--- a/tests/Composer/RecipeTest.php
+++ b/tests/Composer/RecipeTest.php
@@ -92,4 +92,45 @@ class RecipeTest extends TestCase
             'Recipe/core is in the list, we should get all entries from the tree'
         );
     }
+
+    public function testSubsetOfWithRecipeAlreadyInstalled()
+    {
+        $recipe = new Recipe(new Package(SilverstripePackageInfo::RECIPE_CMS));
+
+        // All these packages are implied by recipe CMS
+        $expected = [
+            "silverstripe/admin",
+            "silverstripe/asset-admin",
+            "silverstripe/campaign-admin",
+            "silverstripe/errorpage",
+            "silverstripe/framework"
+        ];
+
+        // Let's add recipe cms to the list
+        $dependencies = array_merge([SilverstripePackageInfo::RECIPE_CMS], $expected);
+
+
+        $results = $recipe->subsetOf($dependencies);
+        $this->assertEquals(
+            sort($expected),
+            sort($results),
+            'When a recipe is already in the list Recipe::subset should return the list of packages that can be removed'
+        );
+    }
+
+    public function testKnownRecipes()
+    {
+        /**
+         * @var Recipe
+         */
+        $recipes = [];
+        foreach (Recipe::getKnownRecipes() as $recipe) {
+            $recipes[$recipe->getName()] = $recipe;
+        }
+
+        $this->assertTrue(isset($recipes['silverstripe/recipe-core']));
+        $this->assertTrue(isset($recipes['silverstripe/recipe-cms']));
+        $this->assertFalse(isset($recipes['silverstripe/cms']));
+        $this->assertFalse(isset($recipes['silverstripe/framework']));
+    }
 }

--- a/tests/Composer/Rules/RebuildTest.php
+++ b/tests/Composer/Rules/RebuildTest.php
@@ -120,7 +120,7 @@ class RebuildTest extends TestCase
         $this->assertArrayNotHasKey(SilverstripePackageInfo::RECIPE_CORE, $require);
         $this->assertArrayNotHasKey(SilverstripePackageInfo::RECIPE_CMS, $require);
 
-        // Test a composer file that doesn't define any recipe but has all undelying package install.
+        // Test a composer file that doesn't define any recipe but has all underlying package install.
         $schema = $composer->initTemporarySchema();
         $pathToCollaboration = __DIR__ . DIRECTORY_SEPARATOR . '..' .
             DIRECTORY_SEPARATOR . 'fixture' .

--- a/tests/Composer/fixture/collaboration-recipe/composer.json
+++ b/tests/Composer/fixture/collaboration-recipe/composer.json
@@ -6,23 +6,23 @@
     "license": "BSD-3-Clause",
     "require": {
 
-        "silverstripe/assets": "1.2.x-dev",
-        "silverstripe/config": "1.0.x-dev",
-        "silverstripe/framework": "4.2.x-dev",
+        "silverstripe/assets": "1.1.0",
+        "silverstripe/config": "1.0.0",
+        "silverstripe/framework": "4.1.0",
 
-        "silverstripe/admin": "1.1.x-dev",
-        "silverstripe/asset-admin": "1.1.x-dev",
-        "silverstripe/campaign-admin": "1.1.x-dev",
-        "silverstripe/cms": "4.1.x-dev",
-        "silverstripe/errorpage": "1.1.x-dev",
-        "silverstripe/graphql": "1.1.x-dev",
-        "silverstripe/reports": "4.1.x-dev",
-        "silverstripe/siteconfig": "4.1.x-dev",
-        "silverstripe/versioned": "1.1.x-dev",
+        "silverstripe/admin": "1.1.0",
+        "silverstripe/asset-admin": "1.1.0",
+        "silverstripe/campaign-admin": "1.1.0",
+        "silverstripe/cms": "4.1.0",
+        "silverstripe/errorpage": "1.1.0",
+        "silverstripe/graphql": "1.1.0",
+        "silverstripe/reports": "4.1.0",
+        "silverstripe/siteconfig": "4.1.0",
+        "silverstripe/versioned": "1.1.0",
 
-        "silverstripe/contentreview": "4.0.x-dev",
-        "silverstripe/sharedraftcontent": "2.x-dev",
-        "symbiote/silverstripe-advancedworkflow": "5.0.x-dev"
+        "silverstripe/contentreview": "4.0.0",
+        "silverstripe/sharedraftcontent": "2.0.0",
+        "symbiote/silverstripe-advancedworkflow": "5.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7"

--- a/tests/Composer/fixture/collaboration-recipe/composer.lock
+++ b/tests/Composer/fixture/collaboration-recipe/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f9dd78262b8e1630d9686de41fa481d1",
+    "content-hash": "0ce88ed848a390bac06c8cf47700073c",
     "packages": [
         {
             "name": "composer/ca-bundle",
-            "version": "1.1.1",
+            "version": "1.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "d2c0a83b7533d6912e8d516756ebd34f893e9169"
+                "reference": "8afa52cd417f4ec417b4bfe86b68106538a87660"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/d2c0a83b7533d6912e8d516756ebd34f893e9169",
-                "reference": "d2c0a83b7533d6912e8d516756ebd34f893e9169",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/8afa52cd417f4ec417b4bfe86b68106538a87660",
+                "reference": "8afa52cd417f4ec417b4bfe86b68106538a87660",
                 "shasum": ""
             },
             "require": {
@@ -60,20 +60,20 @@
                 "ssl",
                 "tls"
             ],
-            "time": "2018-03-29T19:57:20+00:00"
+            "time": "2018-10-18T06:09:13+00:00"
         },
         {
             "name": "composer/installers",
-            "version": "v1.5.0",
+            "version": "v1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/installers.git",
-                "reference": "049797d727261bf27f2690430d935067710049c2"
+                "reference": "cfcca6b1b60bc4974324efb5783c13dca6932b5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/installers/zipball/049797d727261bf27f2690430d935067710049c2",
-                "reference": "049797d727261bf27f2690430d935067710049c2",
+                "url": "https://api.github.com/repos/composer/installers/zipball/cfcca6b1b60bc4974324efb5783c13dca6932b5b",
+                "reference": "cfcca6b1b60bc4974324efb5783c13dca6932b5b",
                 "shasum": ""
             },
             "require": {
@@ -180,20 +180,20 @@
                 "zend",
                 "zikula"
             ],
-            "time": "2017-12-29T09:13:20+00:00"
+            "time": "2018-08-27T06:10:37+00:00"
         },
         {
             "name": "embed/embed",
-            "version": "v3.3.1",
+            "version": "v3.3.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oscarotero/Embed.git",
-                "reference": "038265bc1169f29ef5e19b7210eff1f223c66b0b"
+                "reference": "9666691c78b25047bc6ee7e94823de3eaadce0c6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oscarotero/Embed/zipball/038265bc1169f29ef5e19b7210eff1f223c66b0b",
-                "reference": "038265bc1169f29ef5e19b7210eff1f223c66b0b",
+                "url": "https://api.github.com/repos/oscarotero/Embed/zipball/9666691c78b25047bc6ee7e94823de3eaadce0c6",
+                "reference": "9666691c78b25047bc6ee7e94823de3eaadce0c6",
                 "shasum": ""
             },
             "require": {
@@ -233,7 +233,7 @@
                 "opengraph",
                 "twitter cards"
             ],
-            "time": "2018-02-24T11:23:18+00:00"
+            "time": "2018-10-22T21:59:03+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
@@ -302,16 +302,16 @@
         },
         {
             "name": "intervention/image",
-            "version": "2.4.1",
+            "version": "2.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Intervention/image.git",
-                "reference": "3603dbcc9a17d307533473246a6c58c31cf17919"
+                "reference": "e82d274f786e3d4b866a59b173f42e716f0783eb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Intervention/image/zipball/3603dbcc9a17d307533473246a6c58c31cf17919",
-                "reference": "3603dbcc9a17d307533473246a6c58c31cf17919",
+                "url": "https://api.github.com/repos/Intervention/image/zipball/e82d274f786e3d4b866a59b173f42e716f0783eb",
+                "reference": "e82d274f786e3d4b866a59b173f42e716f0783eb",
                 "shasum": ""
             },
             "require": {
@@ -331,7 +331,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.3-dev"
+                    "dev-master": "2.4-dev"
                 },
                 "laravel": {
                     "providers": [
@@ -368,89 +368,32 @@
                 "thumbnail",
                 "watermark"
             ],
-            "time": "2017-09-21T16:29:17+00:00"
-        },
-        {
-            "name": "league/csv",
-            "version": "8.2.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/thephpleague/csv.git",
-                "reference": "d2aab1e7bde802582c3879acf03d92716577c76d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/csv/zipball/d2aab1e7bde802582c3879acf03d92716577c76d",
-                "reference": "d2aab1e7bde802582c3879acf03d92716577c76d",
-                "shasum": ""
-            },
-            "require": {
-                "ext-mbstring": "*",
-                "php": ">=5.5.0"
-            },
-            "require-dev": {
-                "friendsofphp/php-cs-fixer": "^1.9",
-                "phpunit/phpunit": "^4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "8.2-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "League\\Csv\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ignace Nyamagana Butera",
-                    "email": "nyamsprod@gmail.com",
-                    "homepage": "https://github.com/nyamsprod/",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Csv data manipulation made easy in PHP",
-            "homepage": "http://csv.thephpleague.com",
-            "keywords": [
-                "csv",
-                "export",
-                "filter",
-                "import",
-                "read",
-                "write"
-            ],
-            "time": "2018-02-06T08:27:03+00:00"
+            "time": "2018-05-29T14:19:03+00:00"
         },
         {
             "name": "league/flysystem",
-            "version": "1.0.44",
+            "version": "1.0.48",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "168dbe519737221dc87d17385cde33073881fd02"
+                "reference": "a6ded5b2f6055e2db97b4b859fdfca2b952b78aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/168dbe519737221dc87d17385cde33073881fd02",
-                "reference": "168dbe519737221dc87d17385cde33073881fd02",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/a6ded5b2f6055e2db97b4b859fdfca2b952b78aa",
+                "reference": "a6ded5b2f6055e2db97b4b859fdfca2b952b78aa",
                 "shasum": ""
             },
             "require": {
+                "ext-fileinfo": "*",
                 "php": ">=5.5.9"
             },
             "conflict": {
                 "league/flysystem-sftp": "<1.0.6"
             },
             "require-dev": {
-                "ext-fileinfo": "*",
                 "phpspec/phpspec": "^3.4",
-                "phpunit/phpunit": "^5.7"
+                "phpunit/phpunit": "^5.7.10"
             },
             "suggest": {
                 "ext-fileinfo": "Required for MimeType",
@@ -509,20 +452,20 @@
                 "sftp",
                 "storage"
             ],
-            "time": "2018-04-06T09:58:14+00:00"
+            "time": "2018-10-15T13:53:10+00:00"
         },
         {
             "name": "m1/env",
-            "version": "2.1.0",
+            "version": "2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/m1/Env.git",
-                "reference": "d87eddd031f2aa5450fa04bb1325de8a489b3cd0"
+                "reference": "294addeedf15e1149eeb96ec829f2029d2017d39"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/m1/Env/zipball/d87eddd031f2aa5450fa04bb1325de8a489b3cd0",
-                "reference": "d87eddd031f2aa5450fa04bb1325de8a489b3cd0",
+                "url": "https://api.github.com/repos/m1/Env/zipball/294addeedf15e1149eeb96ec829f2029d2017d39",
+                "reference": "294addeedf15e1149eeb96ec829f2029d2017d39",
                 "shasum": ""
             },
             "require": {
@@ -567,7 +510,7 @@
                 "parser",
                 "support"
             ],
-            "time": "2016-10-06T19:31:28+00:00"
+            "time": "2018-06-19T18:55:08+00:00"
         },
         {
             "name": "marcj/topsort",
@@ -747,16 +690,16 @@
         },
         {
             "name": "paragonie/random_compat",
-            "version": "v2.0.12",
+            "version": "v2.0.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "258c89a6b97de7dfaf5b8c7607d0478e236b04fb"
+                "reference": "29af24f25bab834fcbb38ad2a69fa93b867e070d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/258c89a6b97de7dfaf5b8c7607d0478e236b04fb",
-                "reference": "258c89a6b97de7dfaf5b8c7607d0478e236b04fb",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/29af24f25bab834fcbb38ad2a69fa93b867e070d",
+                "reference": "29af24f25bab834fcbb38ad2a69fa93b867e070d",
                 "shasum": ""
             },
             "require": {
@@ -788,10 +731,11 @@
             "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
             "keywords": [
                 "csprng",
+                "polyfill",
                 "pseudorandom",
                 "random"
             ],
-            "time": "2018-04-04T21:24:14+00:00"
+            "time": "2018-07-04T16:31:37+00:00"
         },
         {
             "name": "psr/cache",
@@ -1035,7 +979,7 @@
         },
         {
             "name": "silverstripe/admin",
-            "version": "1.1.x-dev",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/silverstripe/silverstripe-admin.git",
@@ -1097,16 +1041,16 @@
         },
         {
             "name": "silverstripe/asset-admin",
-            "version": "1.1.x-dev",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/silverstripe/silverstripe-asset-admin.git",
-                "reference": "f642d61cbf301e67fc09c4c402e2f464835162c3"
+                "reference": "4e88f38284b228e15aa8c8478187804c19627c4d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/silverstripe/silverstripe-asset-admin/zipball/f642d61cbf301e67fc09c4c402e2f464835162c3",
-                "reference": "f642d61cbf301e67fc09c4c402e2f464835162c3",
+                "url": "https://api.github.com/repos/silverstripe/silverstripe-asset-admin/zipball/4e88f38284b228e15aa8c8478187804c19627c4d",
+                "reference": "4e88f38284b228e15aa8c8478187804c19627c4d",
                 "shasum": ""
             },
             "require": {
@@ -1117,8 +1061,11 @@
             },
             "require-dev": {
                 "phpunit/phpunit": "^5.7",
+                "se/selenium-server-standalone": "2.41.0",
+                "silverstripe/behat-extension": "^3",
                 "silverstripe/campaign-admin": "^1",
-                "silverstripe/cms": "^4"
+                "silverstripe/cms": "^4",
+                "silverstripe/serve": "^2"
             },
             "type": "silverstripe-vendormodule",
             "extra": {
@@ -1143,26 +1090,26 @@
                 "BSD-3-Clause"
             ],
             "description": "Asset management for the SilverStripe CMS",
-            "time": "2018-04-17T21:35:43+00:00"
+            "time": "2018-02-28T01:31:23+00:00"
         },
         {
             "name": "silverstripe/assets",
-            "version": "1.x-dev",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/silverstripe/silverstripe-assets.git",
-                "reference": "0a9c4bf1a0041a907d268ae8fa48f4eaf3d352da"
+                "reference": "3c3383b95f0e0e9e51a8708c88655c57cdef9f41"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/silverstripe/silverstripe-assets/zipball/0a9c4bf1a0041a907d268ae8fa48f4eaf3d352da",
-                "reference": "0a9c4bf1a0041a907d268ae8fa48f4eaf3d352da",
+                "url": "https://api.github.com/repos/silverstripe/silverstripe-assets/zipball/3c3383b95f0e0e9e51a8708c88655c57cdef9f41",
+                "reference": "3c3383b95f0e0e9e51a8708c88655c57cdef9f41",
                 "shasum": ""
             },
             "require": {
                 "intervention/image": "^2.3",
                 "php": ">=5.6.0",
-                "silverstripe/framework": "^4.1",
+                "silverstripe/framework": "^4@dev",
                 "silverstripe/vendor-plugin": "^1.0"
             },
             "require-dev": {
@@ -1203,20 +1150,20 @@
                 "assets",
                 "silverstripe"
             ],
-            "time": "2018-04-06T03:10:42+00:00"
+            "time": "2018-03-13T01:21:14+00:00"
         },
         {
             "name": "silverstripe/campaign-admin",
-            "version": "1.1.x-dev",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/silverstripe/silverstripe-campaign-admin.git",
-                "reference": "8259d900609ec8c1aa7ab59e04ba5f498cc917a1"
+                "reference": "ce283d18f601bc9aa1e15d5ee9627d574b8b6270"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/silverstripe/silverstripe-campaign-admin/zipball/8259d900609ec8c1aa7ab59e04ba5f498cc917a1",
-                "reference": "8259d900609ec8c1aa7ab59e04ba5f498cc917a1",
+                "url": "https://api.github.com/repos/silverstripe/silverstripe-campaign-admin/zipball/ce283d18f601bc9aa1e15d5ee9627d574b8b6270",
+                "reference": "ce283d18f601bc9aa1e15d5ee9627d574b8b6270",
                 "shasum": ""
             },
             "require": {
@@ -1227,8 +1174,11 @@
             },
             "require-dev": {
                 "phpunit/phpunit": "^5.7",
-                "silverstripe/asset-admin": "^1",
-                "silverstripe/cms": "^4"
+                "se/selenium-server-standalone": "2.41.0",
+                "silverstripe/asset-admin": "^1@dev",
+                "silverstripe/behat-extension": "^3",
+                "silverstripe/cms": "^4@dev",
+                "silverstripe/serve": "^2"
             },
             "type": "silverstripe-vendormodule",
             "extra": {
@@ -1270,20 +1220,20 @@
                 "silverstripe",
                 "versioned"
             ],
-            "time": "2018-04-18T12:15:04+00:00"
+            "time": "2018-02-07T04:22:17+00:00"
         },
         {
             "name": "silverstripe/cms",
-            "version": "4.1.x-dev",
+            "version": "4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/silverstripe/silverstripe-cms.git",
-                "reference": "61429c17a69c1e250ea7ab290ee5259f729b71ff"
+                "reference": "9bf05b397f1bcb0522fa6e773f12be394f3ce7e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/silverstripe/silverstripe-cms/zipball/61429c17a69c1e250ea7ab290ee5259f729b71ff",
-                "reference": "61429c17a69c1e250ea7ab290ee5259f729b71ff",
+                "url": "https://api.github.com/repos/silverstripe/silverstripe-cms/zipball/9bf05b397f1bcb0522fa6e773f12be394f3ce7e5",
+                "reference": "9bf05b397f1bcb0522fa6e773f12be394f3ce7e5",
                 "shasum": ""
             },
             "require": {
@@ -1296,7 +1246,10 @@
                 "silverstripe/versioned": "^1.1@dev"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.7"
+                "phpunit/phpunit": "^5.7",
+                "se/selenium-server-standalone": "2.41.0",
+                "silverstripe/behat-extension": "^3@dev",
+                "silverstripe/serve": "^2"
             },
             "type": "silverstripe-vendormodule",
             "extra": {
@@ -1336,20 +1289,20 @@
                 "cms",
                 "silverstripe"
             ],
-            "time": "2018-04-12T22:03:47+00:00"
+            "time": "2018-03-13T20:45:54+00:00"
         },
         {
             "name": "silverstripe/config",
-            "version": "1.0.x-dev",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/silverstripe/silverstripe-config.git",
-                "reference": "e9c4bd86b4790677694dc8e830bc235e1f19c433"
+                "reference": "266b830f45611261cd6011f4d1e36fc0747485cc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/silverstripe/silverstripe-config/zipball/e9c4bd86b4790677694dc8e830bc235e1f19c433",
-                "reference": "e9c4bd86b4790677694dc8e830bc235e1f19c433",
+                "url": "https://api.github.com/repos/silverstripe/silverstripe-config/zipball/266b830f45611261cd6011f4d1e36fc0747485cc",
+                "reference": "266b830f45611261cd6011f4d1e36fc0747485cc",
                 "shasum": ""
             },
             "require": {
@@ -1375,20 +1328,20 @@
                 "BSD-3-Clause"
             ],
             "description": "SilverStripe configuration based on YAML and class statics",
-            "time": "2018-04-23T00:13:43+00:00"
+            "time": "2017-10-11T04:31:34+00:00"
         },
         {
             "name": "silverstripe/contentreview",
-            "version": "dev-master",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/silverstripe/silverstripe-contentreview.git",
-                "reference": "a20a29b1f0b2fee4f97cdb7d5e35b7f549e57aa8"
+                "reference": "f5052ed511aa6f9e02bd4c924d19e37d9124f9ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/silverstripe/silverstripe-contentreview/zipball/a20a29b1f0b2fee4f97cdb7d5e35b7f549e57aa8",
-                "reference": "a20a29b1f0b2fee4f97cdb7d5e35b7f549e57aa8",
+                "url": "https://api.github.com/repos/silverstripe/silverstripe-contentreview/zipball/f5052ed511aa6f9e02bd4c924d19e37d9124f9ce",
+                "reference": "f5052ed511aa6f9e02bd4c924d19e37d9124f9ce",
                 "shasum": ""
             },
             "require": {
@@ -1444,11 +1397,11 @@
                 "silverstripe",
                 "workflow"
             ],
-            "time": "2018-04-03T22:17:01+00:00"
+            "time": "2018-01-12T00:18:25+00:00"
         },
         {
             "name": "silverstripe/errorpage",
-            "version": "1.1.x-dev",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/silverstripe/silverstripe-errorpage.git",
@@ -1505,16 +1458,16 @@
         },
         {
             "name": "silverstripe/framework",
-            "version": "4.x-dev",
+            "version": "4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/silverstripe/silverstripe-framework.git",
-                "reference": "c5b0bd8a13989deb22c9b08d8242894aa2638a74"
+                "reference": "caefab774e8ab22ef48d8c1b4112450d103ec006"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/silverstripe/silverstripe-framework/zipball/c5b0bd8a13989deb22c9b08d8242894aa2638a74",
-                "reference": "c5b0bd8a13989deb22c9b08d8242894aa2638a74",
+                "url": "https://api.github.com/repos/silverstripe/silverstripe-framework/zipball/caefab774e8ab22ef48d8c1b4112450d103ec006",
+                "reference": "caefab774e8ab22ef48d8c1b4112450d103ec006",
                 "shasum": ""
             },
             "require": {
@@ -1529,7 +1482,6 @@
                 "ext-simplexml": "*",
                 "ext-tokenizer": "*",
                 "ext-xml": "*",
-                "league/csv": "^8",
                 "league/flysystem": "~1.0.12",
                 "m1/env": "^2.1",
                 "monolog/monolog": "~1.11",
@@ -1552,7 +1504,10 @@
             },
             "require-dev": {
                 "phpunit/phpunit": "^5.7",
-                "silverstripe/versioned": "^1"
+                "se/selenium-server-standalone": "2.41.0",
+                "silverstripe/behat-extension": "^3",
+                "silverstripe/serve": "^2@dev",
+                "silverstripe/versioned": "^1@dev"
             },
             "bin": [
                 "sake"
@@ -1560,7 +1515,8 @@
             "type": "silverstripe-vendormodule",
             "extra": {
                 "branch-alias": {
-                    "4.x-dev": "4.2.x-dev"
+                    "4.x-dev": "4.2.x-dev",
+                    "dev-master": "5.x-dev"
                 },
                 "expose": [
                     "client/images",
@@ -1619,20 +1575,20 @@
                 "framework",
                 "silverstripe"
             ],
-            "time": "2018-04-30T10:58:40+00:00"
+            "time": "2018-03-13T21:16:31+00:00"
         },
         {
             "name": "silverstripe/graphql",
-            "version": "1.1.x-dev",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/silverstripe/silverstripe-graphql.git",
-                "reference": "0a55d8a6024ad295d7e05b68bf73dc80bf4b1ac6"
+                "reference": "4a7a972b1ed81bea53727d4373e8ad56694e6510"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/silverstripe/silverstripe-graphql/zipball/0a55d8a6024ad295d7e05b68bf73dc80bf4b1ac6",
-                "reference": "0a55d8a6024ad295d7e05b68bf73dc80bf4b1ac6",
+                "url": "https://api.github.com/repos/silverstripe/silverstripe-graphql/zipball/4a7a972b1ed81bea53727d4373e8ad56694e6510",
+                "reference": "4a7a972b1ed81bea53727d4373e8ad56694e6510",
                 "shasum": ""
             },
             "require": {
@@ -1650,7 +1606,7 @@
             "extra": {
                 "branch-alias": {
                     "1.x-dev": "1.2.x-dev",
-                    "dev-master": "3.x-dev"
+                    "dev-master": "2.x-dev"
                 }
             },
             "autoload": {
@@ -1660,11 +1616,11 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "description": "GraphQL server for SilverStripe models and other data",
-            "time": "2018-03-19T23:02:42+00:00"
+            "time": "2018-02-22T04:13:58+00:00"
         },
         {
             "name": "silverstripe/reports",
-            "version": "4.1.x-dev",
+            "version": "4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/silverstripe/silverstripe-reports.git",
@@ -1728,16 +1684,16 @@
         },
         {
             "name": "silverstripe/sharedraftcontent",
-            "version": "dev-master",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/silverstripe/silverstripe-sharedraftcontent.git",
-                "reference": "07b8299d599318771c78e22cf7eb06150c79207a"
+                "reference": "2791b5fcd8389eae2862160b2555c0ae25dfc248"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/silverstripe/silverstripe-sharedraftcontent/zipball/07b8299d599318771c78e22cf7eb06150c79207a",
-                "reference": "07b8299d599318771c78e22cf7eb06150c79207a",
+                "url": "https://api.github.com/repos/silverstripe/silverstripe-sharedraftcontent/zipball/2791b5fcd8389eae2862160b2555c0ae25dfc248",
+                "reference": "2791b5fcd8389eae2862160b2555c0ae25dfc248",
                 "shasum": ""
             },
             "require": {
@@ -1785,20 +1741,20 @@
             "keywords": [
                 "silverstripe"
             ],
-            "time": "2018-03-23T06:47:59+00:00"
+            "time": "2018-01-31T22:55:31+00:00"
         },
         {
             "name": "silverstripe/siteconfig",
-            "version": "4.1.x-dev",
+            "version": "4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/silverstripe/silverstripe-siteconfig.git",
-                "reference": "32dd00e0bea6e0b732c2e0dfafb7a32b6c3758f5"
+                "reference": "ee388c0d174611cb1b0edd52d0a9614c6381f326"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/silverstripe/silverstripe-siteconfig/zipball/32dd00e0bea6e0b732c2e0dfafb7a32b6c3758f5",
-                "reference": "32dd00e0bea6e0b732c2e0dfafb7a32b6c3758f5",
+                "url": "https://api.github.com/repos/silverstripe/silverstripe-siteconfig/zipball/ee388c0d174611cb1b0edd52d0a9614c6381f326",
+                "reference": "ee388c0d174611cb1b0edd52d0a9614c6381f326",
                 "shasum": ""
             },
             "require": {
@@ -1807,7 +1763,10 @@
                 "silverstripe/vendor-plugin": "^1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.7"
+                "phpunit/phpunit": "^5.7",
+                "se/selenium-server-standalone": "2.41.0",
+                "silverstripe/behat-extension": "^3",
+                "silverstripe/serve": "^2"
             },
             "type": "silverstripe-vendormodule",
             "autoload": {
@@ -1831,7 +1790,7 @@
                 "silverstripe",
                 "siteconfig"
             ],
-            "time": "2018-04-25T22:42:38+00:00"
+            "time": "2018-03-13T20:45:54+00:00"
         },
         {
             "name": "silverstripe/vendor-plugin",
@@ -1883,7 +1842,7 @@
         },
         {
             "name": "silverstripe/versioned",
-            "version": "1.1.x-dev",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/silverstripe/silverstripe-versioned.git",
@@ -1934,16 +1893,16 @@
         },
         {
             "name": "swiftmailer/swiftmailer",
-            "version": "v5.4.9",
+            "version": "v5.4.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/swiftmailer/swiftmailer.git",
-                "reference": "7ffc1ea296ed14bf8260b6ef11b80208dbadba91"
+                "reference": "181b89f18a90f8925ef805f950d47a7190e9b950"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/7ffc1ea296ed14bf8260b6ef11b80208dbadba91",
-                "reference": "7ffc1ea296ed14bf8260b6ef11b80208dbadba91",
+                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/181b89f18a90f8925ef805f950d47a7190e9b950",
+                "reference": "181b89f18a90f8925ef805f950d47a7190e9b950",
                 "shasum": ""
             },
             "require": {
@@ -1984,51 +1943,30 @@
                 "mail",
                 "mailer"
             ],
-            "time": "2018-01-23T07:37:21+00:00"
+            "time": "2018-07-31T09:26:32+00:00"
         },
         {
             "name": "symbiote/silverstripe-advancedworkflow",
-            "version": "5.0.x-dev",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symbiote/silverstripe-advancedworkflow.git",
-                "reference": "e4150fdef28203fbc2860f3afacea0c536365583"
+                "reference": "77e4cc91fb232515c717357fca5243192f6af246"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symbiote/silverstripe-advancedworkflow/zipball/e4150fdef28203fbc2860f3afacea0c536365583",
-                "reference": "e4150fdef28203fbc2860f3afacea0c536365583",
+                "url": "https://api.github.com/repos/symbiote/silverstripe-advancedworkflow/zipball/77e4cc91fb232515c717357fca5243192f6af246",
+                "reference": "77e4cc91fb232515c717357fca5243192f6af246",
                 "shasum": ""
             },
             "require": {
-                "silverstripe/admin": "^1",
                 "silverstripe/cms": "^4",
-                "silverstripe/framework": "^4",
-                "silverstripe/versioned": "^1",
-                "symfony/yaml": "~3.2"
+                "silverstripe/framework": "^4"
             },
-            "replace": {
-                "silverstripe/advancedworkflow": "self.version"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^5.7",
-                "squizlabs/php_codesniffer": "^3.0"
-            },
-            "suggest": {
-                "symbiote/silverstripe-queuedjobs": "Allow automated workflow transitions with queued system jobs"
-            },
-            "type": "silverstripe-vendormodule",
+            "type": "silverstripe-module",
             "extra": {
-                "expose": [
-                    "client/dist",
-                    "client/lang",
-                    "images"
-                ]
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symbiote\\AdvancedWorkflow\\": "src/",
-                    "Symbiote\\AdvancedWorkflow\\Tests\\": "tests/"
+                "branch-alias": {
+                    "dev-master": "5.0.x-dev"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2051,20 +1989,20 @@
                 "silverstripe",
                 "workflow"
             ],
-            "time": "2018-04-08T22:38:22+00:00"
+            "time": "2017-06-23T01:31:32+00:00"
         },
         {
             "name": "symfony/cache",
-            "version": "v3.4.9",
+            "version": "v3.4.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache.git",
-                "reference": "51a9eef3091b2c06f63d8b1b98de9d101b5e0e77"
+                "reference": "4f29972d3fae5febec5c18db70e7dd2957e74ad6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache/zipball/51a9eef3091b2c06f63d8b1b98de9d101b5e0e77",
-                "reference": "51a9eef3091b2c06f63d8b1b98de9d101b5e0e77",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/4f29972d3fae5febec5c18db70e7dd2957e74ad6",
+                "reference": "4f29972d3fae5febec5c18db70e7dd2957e74ad6",
                 "shasum": ""
             },
             "require": {
@@ -2121,25 +2059,26 @@
                 "caching",
                 "psr6"
             ],
-            "time": "2018-04-27T05:49:57+00:00"
+            "time": "2018-09-25T07:13:51+00:00"
         },
         {
             "name": "symfony/config",
-            "version": "v3.4.9",
+            "version": "v3.4.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "7c2a9d44f4433863e9bca682e7f03609234657f9"
+                "reference": "99b2fa8acc244e656cdf324ff419fbe6fd300a4d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/7c2a9d44f4433863e9bca682e7f03609234657f9",
-                "reference": "7c2a9d44f4433863e9bca682e7f03609234657f9",
+                "url": "https://api.github.com/repos/symfony/config/zipball/99b2fa8acc244e656cdf324ff419fbe6fd300a4d",
+                "reference": "99b2fa8acc244e656cdf324ff419fbe6fd300a4d",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.5.9|>=7.0.8",
-                "symfony/filesystem": "~2.8|~3.0|~4.0"
+                "symfony/filesystem": "~2.8|~3.0|~4.0",
+                "symfony/polyfill-ctype": "~1.8"
             },
             "conflict": {
                 "symfony/dependency-injection": "<3.3",
@@ -2184,29 +2123,30 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2018-03-19T22:32:39+00:00"
+            "time": "2018-10-31T09:06:03+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v4.0.9",
+            "version": "v4.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "5d2d655b2c72fc4d9bf7e9bf14f72a447b940f21"
+                "reference": "fd7bd6535beb1f0a0a9e3ee960666d0598546981"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/5d2d655b2c72fc4d9bf7e9bf14f72a447b940f21",
-                "reference": "5d2d655b2c72fc4d9bf7e9bf14f72a447b940f21",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/fd7bd6535beb1f0a0a9e3ee960666d0598546981",
+                "reference": "fd7bd6535beb1f0a0a9e3ee960666d0598546981",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3"
+                "php": "^7.1.3",
+                "symfony/polyfill-ctype": "~1.8"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-master": "4.1-dev"
                 }
             },
             "autoload": {
@@ -2233,20 +2173,20 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2018-02-22T10:50:29+00:00"
+            "time": "2018-10-30T13:18:25+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v3.4.9",
+            "version": "v3.4.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "bd14efe8b1fabc4de82bf50dce62f05f9a102433"
+                "reference": "54ba444dddc5bd5708a34bd095ea67c6eb54644d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/bd14efe8b1fabc4de82bf50dce62f05f9a102433",
-                "reference": "bd14efe8b1fabc4de82bf50dce62f05f9a102433",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/54ba444dddc5bd5708a34bd095ea67c6eb54644d",
+                "reference": "54ba444dddc5bd5708a34bd095ea67c6eb54644d",
                 "shasum": ""
             },
             "require": {
@@ -2282,20 +2222,20 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2018-04-04T05:07:11+00:00"
+            "time": "2018-10-03T08:46:40+00:00"
         },
         {
             "name": "symfony/polyfill-apcu",
-            "version": "v1.7.0",
+            "version": "v1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-apcu.git",
-                "reference": "e8ae2136ddb53dea314df56fcd88e318ab936c00"
+                "reference": "19e1b73bf255265ad0b568f81766ae2a3266d8d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-apcu/zipball/e8ae2136ddb53dea314df56fcd88e318ab936c00",
-                "reference": "e8ae2136ddb53dea314df56fcd88e318ab936c00",
+                "url": "https://api.github.com/repos/symfony/polyfill-apcu/zipball/19e1b73bf255265ad0b568f81766ae2a3266d8d2",
+                "reference": "19e1b73bf255265ad0b568f81766ae2a3266d8d2",
                 "shasum": ""
             },
             "require": {
@@ -2304,7 +2244,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.7-dev"
+                    "dev-master": "1.9-dev"
                 }
             },
             "autoload": {
@@ -2338,20 +2278,78 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-01-30T19:27:44+00:00"
+            "time": "2018-08-06T14:22:27+00:00"
         },
         {
-            "name": "symfony/polyfill-mbstring",
-            "version": "v1.7.0",
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.10.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "78be803ce01e55d3491c1397cf1c64beb9c1b63b"
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/78be803ce01e55d3491c1397cf1c64beb9c1b63b",
-                "reference": "78be803ce01e55d3491c1397cf1c64beb9c1b63b",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e3d826245268269cd66f8326bd8bc066687b4a19",
+                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                },
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "time": "2018-08-06T14:22:27+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "c79c051f5b3a46be09205c73b80b346e4153e494"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/c79c051f5b3a46be09205c73b80b346e4153e494",
+                "reference": "c79c051f5b3a46be09205c73b80b346e4153e494",
                 "shasum": ""
             },
             "require": {
@@ -2363,7 +2361,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.7-dev"
+                    "dev-master": "1.9-dev"
                 }
             },
             "autoload": {
@@ -2397,20 +2395,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-01-30T19:27:44+00:00"
+            "time": "2018-09-21T13:07:52+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v2.8.39",
+            "version": "v2.8.47",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "6f744108f846097cb250d90c8c463ddd23b43f60"
+                "reference": "cb34ec9549ab65f7f512819441f2d6af4d12c294"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/6f744108f846097cb250d90c8c463ddd23b43f60",
-                "reference": "6f744108f846097cb250d90c8c463ddd23b43f60",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/cb34ec9549ab65f7f512819441f2d6af4d12c294",
+                "reference": "cb34ec9549ab65f7f512819441f2d6af4d12c294",
                 "shasum": ""
             },
             "require": {
@@ -2461,24 +2459,25 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2018-04-30T01:21:07+00:00"
+            "time": "2018-10-02T16:27:16+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.4.9",
+            "version": "v3.4.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "033cfa61ef06ee0847e056e530201842b6e926c3"
+                "reference": "640b6c27fed4066d64b64d5903a86043f4a4de7f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/033cfa61ef06ee0847e056e530201842b6e926c3",
-                "reference": "033cfa61ef06ee0847e056e530201842b6e926c3",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/640b6c27fed4066d64b64d5903a86043f4a4de7f",
+                "reference": "640b6c27fed4066d64b64d5903a86043f4a4de7f",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8"
+                "php": "^5.5.9|>=7.0.8",
+                "symfony/polyfill-ctype": "~1.8"
             },
             "conflict": {
                 "symfony/console": "<3.4"
@@ -2519,7 +2518,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2018-04-08T08:21:29+00:00"
+            "time": "2018-10-02T16:33:53+00:00"
         },
         {
             "name": "webonyx/graphql-php",
@@ -2621,25 +2620,28 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.7.0",
+            "version": "1.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e"
+                "reference": "3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
-                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8",
+                "reference": "3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.1"
+            },
+            "replace": {
+                "myclabs/deep-copy": "self.version"
             },
             "require-dev": {
                 "doctrine/collections": "^1.0",
                 "doctrine/common": "^2.6",
-                "phpunit/phpunit": "^4.1"
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "autoload": {
@@ -2662,7 +2664,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2017-10-19T19:58:43+00:00"
+            "time": "2018-06-11T23:09:50+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -2818,16 +2820,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.7.6",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "33a7e3c4fda54e912ff6338c48823bd5c0f0b712"
+                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/33a7e3c4fda54e912ff6338c48823bd5c0f0b712",
-                "reference": "33a7e3c4fda54e912ff6338c48823bd5c0f0b712",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
+                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
                 "shasum": ""
             },
             "require": {
@@ -2839,12 +2841,12 @@
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.7.x-dev"
+                    "dev-master": "1.8.x-dev"
                 }
             },
             "autoload": {
@@ -2877,7 +2879,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2018-04-18T13:57:24+00:00"
+            "time": "2018-08-05T17:53:17+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -3835,23 +3837,7 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {
-        "silverstripe/assets": 20,
-        "silverstripe/config": 20,
-        "silverstripe/framework": 20,
-        "silverstripe/admin": 20,
-        "silverstripe/asset-admin": 20,
-        "silverstripe/campaign-admin": 20,
-        "silverstripe/cms": 20,
-        "silverstripe/errorpage": 20,
-        "silverstripe/graphql": 20,
-        "silverstripe/reports": 20,
-        "silverstripe/siteconfig": 20,
-        "silverstripe/versioned": 20,
-        "silverstripe/contentreview": 20,
-        "silverstripe/sharedraftcontent": 20,
-        "symbiote/silverstripe-advancedworkflow": 20
-    },
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": [],


### PR DESCRIPTION
This should allow recompose unit tests to go green. It's still relying on remote dependencies, but at least we'll target specific stable release now, which should minimise the risk of new releases breaking the test.

I've also added some minor tweaks so that 
* packages that are implicitly required by a recipe get removed if that recipe is already present ;
* disable composer plugins in most cases which should provide a minor speed boost and avoid potential conflicts.