### PR TITLE
MINOR: Add ability for upgrader to display warnings for ambiguous class renames

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ You can run this command (with a necessary refresh of composer autoload files) w
 
 ```bash
 composer dump-autoload
-upgrade-code inspect <path> [--root-dir=<root>] [--write] [-vvv] [--skip-visibility]
+upgrade-code inspect <path> [--root-dir=<root>] [--write] [-vvv] [--skip-visibility] [---prompt]
 ```
 
 This will load all classes into memory and infer the types of all objects used in each file. It will
@@ -216,6 +216,20 @@ use these inferred types to automatically update method usages.
 The command updates properties and functions to use the correct visibility of its parent if possible.
 
 Add the `--skip-visibility` option to ignore this.
+
+#### Class renaming
+
+You can specify what class renames should be considered ambiguous, example:
+
+```yaml
+renameWarnings:
+  - File
+  - Image
+```
+
+The above config will show warnings when renaming the `File` and `Image` occurrences to their respectful class mappings.
+
+Add the `--prompt` option to manually approve ambiguous class renames.
 
 ### `reorganise`
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ You can run this command (with a necessary refresh of composer autoload files) w
 
 ```bash
 composer dump-autoload
-upgrade-code inspect <path> [--root-dir=<root>] [--write] [-vvv] [--skip-visibility] [---prompt]
+upgrade-code inspect <path> [--root-dir=<root>] [--write] [-vvv] [--skip-visibility]
 ```
 
 This will load all classes into memory and infer the types of all objects used in each file. It will
@@ -216,20 +216,6 @@ use these inferred types to automatically update method usages.
 The command updates properties and functions to use the correct visibility of its parent if possible.
 
 Add the `--skip-visibility` option to ignore this.
-
-#### Class renaming
-
-You can specify what class renames should be considered ambiguous, example:
-
-```yaml
-renameWarnings:
-  - File
-  - Image
-```
-
-The above config will show warnings when renaming the `File` and `Image` occurrences to their respectful class mappings.
-
-Add the `--prompt` option to manually approve ambiguous class renames.
 
 ### `reorganise`
 
@@ -251,7 +237,7 @@ Example:
 Once you have finished [namespacing your code](#add-namespace), you can run the below code to rename all references.
 
 ```bash
-upgrade-code upgrade <path> [--root-dir=<root>] [--write] [--rule] [-vvv]
+upgrade-code upgrade <path> [--root-dir=<root>] [--write] [--rule] [-vvv] [---prompt]
 ```
 
 Example
@@ -319,6 +305,29 @@ upgrade-code upgrade <path> --rule=lang
 
 Since this upgrade is normally only done on projects that provide their own strings,
 this rule is not included by default when running a normal upgrade.
+
+#### Class renaming
+
+Class mappings can be used to convert string literal references to namespaced classes. Sometimes it is unclear whether a string literal is referring to the mapped class or not. This is where `renameWarnings` are handy.
+
+An example of an ambiguous rename would be:
+```PHP
+private static $has_one = [
+    'Image' => 'Image',
+];
+```
+
+You can specify what class renames should be considered ambiguous with yaml:
+
+```yaml
+renameWarnings:
+  - File
+  - Image
+```
+
+The above config will show warnings when renaming the `File` and `Image` occurrences to their respectful class mappings.
+
+Add the `--prompt` option to manually approve ambiguous class renames.
 
 ## .upgrade.yml spec
 

--- a/src/Console/UpgradeCommand.php
+++ b/src/Console/UpgradeCommand.php
@@ -37,6 +37,12 @@ class UpgradeCommand extends AbstractCommand implements AutomatedCommand
                     . "<comment> [allowed: [\"code\",\"config\",\"lang\"]]</comment>\n",
                     ['code', 'config']
                 ),
+                new InputOption(
+                    'prompt',
+                    'p',
+                    InputOption::VALUE_NONE,
+                    "Show a prompt before making ambiguous class replacements."
+                ),
                 $this->getRootInputOption(),
                 $this->getWriteInputOption()
             ]);
@@ -116,7 +122,7 @@ class UpgradeCommand extends AbstractCommand implements AutomatedCommand
         // Build rules for this set of upgrades
         $ruleObjects = [];
         if (in_array('code', $rules)) {
-            $ruleObjects[] = new RenameClasses();
+            $ruleObjects[] = new RenameClasses($input->getOption('prompt'));
         }
         if (in_array('config', $rules)) {
             $ruleObjects[] = new UpdateConfigClasses();

--- a/src/Console/UpgradeCommand.php
+++ b/src/Console/UpgradeCommand.php
@@ -71,7 +71,7 @@ class UpgradeCommand extends AbstractCommand implements AutomatedCommand
     {
         // Build spec
         $spec = new UpgradeSpec();
-        $rules = $this->getRules($input);
+        $rules = $this->getRules($input, $output);
         $rootPath = $this->getRootPath($input);
         $config = $this->getConfig($rootPath);
         foreach ($rules as $rule) {
@@ -106,9 +106,11 @@ class UpgradeCommand extends AbstractCommand implements AutomatedCommand
 
     /**
      * @param InputInterface $input
+     * @param $output
+     * @param $command
      * @return array
      */
-    protected function getRules($input): array
+    protected function getRules($input, $output): array
     {
         $rules = $input->getOption('rule');
         $allowed = ['code', 'config', 'lang'];
@@ -122,7 +124,7 @@ class UpgradeCommand extends AbstractCommand implements AutomatedCommand
         // Build rules for this set of upgrades
         $ruleObjects = [];
         if (in_array('code', $rules)) {
-            $ruleObjects[] = new RenameClasses($input->getOption('prompt'));
+            $ruleObjects[] = new RenameClasses($input->getOption('prompt'), $this, $input, $output);
         }
         if (in_array('config', $rules)) {
             $ruleObjects[] = new UpdateConfigClasses();

--- a/src/UpgradeRule/PHP/RenameClasses.php
+++ b/src/UpgradeRule/PHP/RenameClasses.php
@@ -8,18 +8,45 @@ use SilverStripe\Upgrader\CodeCollection\ItemInterface;
 use SilverStripe\Upgrader\UpgradeRule\PHP\Visitor\ParentConnector;
 use SilverStripe\Upgrader\UpgradeRule\PHP\Visitor\RenameClassesVisitor;
 use SilverStripe\Upgrader\Util\MutableSource;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class RenameClasses extends PHPUpgradeRule
 {
+    /**
+     * @var bool
+     */
     private $showPrompt;
+
+    /**
+     * @var Command
+     */
+    protected $command;
+
+    /**
+     * @var InputInterface
+     */
+    protected $input;
+
+    /**
+     * @var OutputInterface
+     */
+    protected $output;
 
     /**
      * RenameClasses constructor.
      * @param bool $showPrompt
+     * @param $command
+     * @param $input
+     * @param $output
      */
-    public function __construct($showPrompt = false)
+    public function __construct($showPrompt = false, $command = null, $input = null, $output = null)
     {
         $this->showPrompt = $showPrompt;
+        $this->command = $command;
+        $this->input = $input;
+        $this->output = $output;
     }
 
     public function upgradeFile($contents, ItemInterface $file, CodeChangeSet $changeset)
@@ -38,7 +65,7 @@ class RenameClasses extends PHPUpgradeRule
         $this->transformWithVisitors($source->getAst(), [
             new NameResolver(), // Add FQN for class references
             new ParentConnector(), // Link child nodes to parents
-            new RenameClassesVisitor($source, $mappings, $skipConfig, $renameWarnings, $showPrompt, $changeset, $file),
+            new RenameClassesVisitor($source, $mappings, $skipConfig, $renameWarnings, $showPrompt, $changeset, $file, $this->command, $this->input, $this->output),
         ]);
 
         return $source->getModifiedString();

--- a/src/UpgradeRule/PHP/RenameClasses.php
+++ b/src/UpgradeRule/PHP/RenameClasses.php
@@ -65,7 +65,18 @@ class RenameClasses extends PHPUpgradeRule
         $this->transformWithVisitors($source->getAst(), [
             new NameResolver(), // Add FQN for class references
             new ParentConnector(), // Link child nodes to parents
-            new RenameClassesVisitor($source, $mappings, $skipConfig, $renameWarnings, $showPrompt, $changeset, $file, $this->command, $this->input, $this->output),
+            new RenameClassesVisitor(
+                $source,
+                $mappings,
+                $skipConfig,
+                $renameWarnings,
+                $showPrompt,
+                $changeset,
+                $file,
+                $this->command,
+                $this->input,
+                $this->output
+            )
         ]);
 
         return $source->getModifiedString();

--- a/src/UpgradeRule/PHP/RenameClasses.php
+++ b/src/UpgradeRule/PHP/RenameClasses.php
@@ -11,6 +11,17 @@ use SilverStripe\Upgrader\Util\MutableSource;
 
 class RenameClasses extends PHPUpgradeRule
 {
+    private $showPrompt;
+
+    /**
+     * RenameClasses constructor.
+     * @param bool $showPrompt
+     */
+    public function __construct($showPrompt = false)
+    {
+        $this->showPrompt = $showPrompt;
+    }
+
     public function upgradeFile($contents, ItemInterface $file, CodeChangeSet $changeset)
     {
         if (!$this->appliesTo($file)) {
@@ -21,11 +32,13 @@ class RenameClasses extends PHPUpgradeRule
 
         $mappings = isset($this->parameters['mappings']) ? $this->parameters['mappings'] : [];
         $skipConfig = isset($this->parameters['skipConfigs']) ? $this->parameters['skipConfigs'] : [];
+        $renameWarnings = isset($this->parameters['renameWarnings']) ? $this->parameters['renameWarnings'] : [];
+        $showPrompt = $this->showPrompt;
 
         $this->transformWithVisitors($source->getAst(), [
             new NameResolver(), // Add FQN for class references
             new ParentConnector(), // Link child nodes to parents
-            new RenameClassesVisitor($source, $mappings, $skipConfig),
+            new RenameClassesVisitor($source, $mappings, $skipConfig, $renameWarnings, $showPrompt, $changeset, $file),
         ]);
 
         return $source->getModifiedString();

--- a/src/UpgradeRule/PHP/Visitor/RenameClassesVisitor.php
+++ b/src/UpgradeRule/PHP/Visitor/RenameClassesVisitor.php
@@ -150,12 +150,15 @@ class RenameClassesVisitor extends NodeVisitorAbstract
 
             // Show warning if this replacement may be invalid
             if (isset($this->renameWarnings[$baseName]) && $this->showPrompt) {
-
-                $before = $this->source->getNodeLine($stringNode, 'question');
-                $str = 'Attempting to rename: ' . PHP_EOL . $before . PHP_EOL
-                    . 'Do you want to rename '
-                    . $baseName . " to " . $replacement
-                    . " at {$this->file->getPath()}:{$stringNode->getLine()}? (Y/n)";
+                $line = $this->source->getNodeLine($stringNode, 'question');
+                $str = sprintf(
+                    "Attempting to rename:\n%s\nDo you want to rename %s to %s at %s:%s?",
+                    $line,
+                    $baseName,
+                    $replacement,
+                    $this->file->getPath(),
+                    $stringNode->getLine()
+                );
 
                 $helper = $this->command->getHelper('question');
                 $question = new ConfirmationQuestion($str, true);
@@ -173,13 +176,13 @@ class RenameClassesVisitor extends NodeVisitorAbstract
                 $this->changeSet->addWarning(
                     $this->file->getPath(),
                     $stringNode->getLine(),
-                    "Renaming ambiguous string <error>" . $baseName . "</error> to <info>" . $replacement . "</info>\n"
+                    "Renaming ambiguous string <info>" . $baseName . "</info> to <info>" . $replacement . "</info>\n"
                 );
             } else {
                 $this->changeSet->addWarning(
                     $this->file->getPath(),
                     $stringNode->getLine(),
-                    "Skipping renaming of ambiguous string from <error>" . $baseName . "</error> to <info>" . $replacement . "</info>\n"
+                    "Skipping renaming of ambiguous string from <info>" . $baseName . "</info> to <info>" . $replacement . "</info>\n"
                 );
             }
         }

--- a/src/UpgradeRule/PHP/Visitor/RenameClassesVisitor.php
+++ b/src/UpgradeRule/PHP/Visitor/RenameClassesVisitor.php
@@ -164,6 +164,11 @@ class RenameClassesVisitor extends NodeVisitorAbstract
                 $question = new ConfirmationQuestion($str, true);
 
                 if (!$helper->ask($this->input, $this->output, $question)) {
+                    $this->changeSet->addWarning(
+                        $this->file->getPath(),
+                        $stringNode->getLine(),
+                        "Skipping renaming of ambiguous string from <info>" . $baseName . "</info> to <info>" . $replacement . "</info>\n"
+                    );
                     return;
                 }
             }
@@ -177,12 +182,6 @@ class RenameClassesVisitor extends NodeVisitorAbstract
                     $this->file->getPath(),
                     $stringNode->getLine(),
                     "Renaming ambiguous string <info>" . $baseName . "</info> to <info>" . $replacement . "</info>\n"
-                );
-            } else {
-                $this->changeSet->addWarning(
-                    $this->file->getPath(),
-                    $stringNode->getLine(),
-                    "Skipping renaming of ambiguous string from <info>" . $baseName . "</info> to <info>" . $replacement . "</info>\n"
                 );
             }
         }

--- a/src/UpgradeRule/PHP/Visitor/RenameClassesVisitor.php
+++ b/src/UpgradeRule/PHP/Visitor/RenameClassesVisitor.php
@@ -167,7 +167,11 @@ class RenameClassesVisitor extends NodeVisitorAbstract
                     $this->changeSet->addWarning(
                         $this->file->getPath(),
                         $stringNode->getLine(),
-                        "Skipping renaming of ambiguous string from <info>" . $baseName . "</info> to <info>" . $replacement . "</info>\n"
+                        sprintf(
+                            "Skipping renaming of ambiguous string from <info>%s</info> to <info>%s</info>\n",
+                            $baseName,
+                            $replacement
+                        )
                     );
                     return;
                 }
@@ -181,7 +185,11 @@ class RenameClassesVisitor extends NodeVisitorAbstract
                 $this->changeSet->addWarning(
                     $this->file->getPath(),
                     $stringNode->getLine(),
-                    "Renaming ambiguous string <info>" . $baseName . "</info> to <info>" . $replacement . "</info>\n"
+                    sprintf(
+                        "Renaming ambiguous string <info>%s</info> to <info>%s</info>\n",
+                        $baseName,
+                        $replacement
+                    )
                 );
             }
         }

--- a/src/Util/MutableSource.php
+++ b/src/Util/MutableSource.php
@@ -114,6 +114,34 @@ class MutableSource
     }
 
     /**
+     * Returns the full line the node belongs to
+     *
+     * @param Node $node
+     * @param string|null $tag A tag to add to the node
+     * @return bool|string
+     */
+    public function getNodeLine(Node $node, $tag = null)
+    {
+        list($start, $length) = $this->nodeRange($node);
+        $end = $start + $length;
+
+        $str = $this->getOrigString();
+        $lineStart = strrpos($str, "\n", -strlen($str)+$start);
+        $lineStart = $lineStart ? $lineStart + 1: $start;
+        $lineEnd = strpos($str, "\n", $end) ?: $end;
+        $lineLength = $lineEnd - $lineStart;
+
+        $line = substr($str, $lineStart, $lineLength);
+
+        if ($tag) {
+            $line = substr_replace($line, "<$tag>", $start - $lineStart, 0);
+            $line = substr_replace($line, "</$tag>", $end - $lineEnd + $lineLength + strlen("<$tag>"), 0);
+        }
+
+        return $line;
+    }
+
+    /**
      * @param int $pos Position to insert before
      * @param string|Node|array The entity to insert. A string, Node, or array of Nodes
      */

--- a/tests/UpgradeRule/PHP/RenameClassesTest.php
+++ b/tests/UpgradeRule/PHP/RenameClassesTest.php
@@ -45,4 +45,24 @@ class RenameClassesTest extends TestCase
         $this->assertFalse($changset->hasWarnings('test.php'));
         $this->assertEquals($output, $generated);
     }
+
+    public function testRenameClasses()
+    {
+        $fixture = 'ambiguous-renames.testfixture';
+
+        list($parameters, $input, $output) = $this->loadFixture(__DIR__.'/fixtures/'.$fixture);
+        $updater = (new RenameClasses())->withParameters($parameters);
+
+        // Build mock collection
+        $code = new MockCodeCollection([
+            'test.php' => $input
+        ]);
+        $file = $code->itemByPath('test.php');
+        $changeset = new CodeChangeSet();
+
+        $generated = $updater->upgradeFile($input, $file, $changeset);
+
+        $this->assertTrue($changeset->hasWarnings('test.php'));
+        $this->assertEquals($output, $generated);
+    }
 }

--- a/tests/UpgradeRule/PHP/fixtures/ambiguous-renames.testfixture
+++ b/tests/UpgradeRule/PHP/fixtures/ambiguous-renames.testfixture
@@ -1,0 +1,88 @@
+{
+    "mappings": {
+        "ExampleField": "SilverStripe\\Fields\\ExampleField",
+        "ExampleInterface": "SilverStripe\\Fields\\RenamedInterface",
+        "MySpace\\SpaceClass": "SpaceClass",
+        "ExampleNamespace\\NextExampleField": "SilverStripe\\Fields\\NextExampleField",
+        "MySpace\\ExampleField3": "SilverStripe\\Fields\\RenamedExampleField3",
+        "MySpace\\A": "MySpace\\Aye",
+        "MySpace\\B": "MySpace\\Bee",
+        "MySpace\\Traitor": "TraitSpace\\Traitee",
+        "Exception": "MySpace\\NewException",
+        "File": "SilverStripe\\Assets\\File",
+        "Image": "SilverStripe\\Assets\\Image"
+    },
+    "renameWarnings": [
+        "File",
+        "Image"
+    ]
+}
+------
+<?php
+
+use SilverStripe\AssetAdmin\Forms\UploadField;
+use SilverStripe\ORM\DataObject;
+
+class Food extends DataObject
+{
+    private static $db = [
+        'Name' => 'Varchar',
+    ];
+
+    private static $has_one = [
+        'File' => 'File',
+    ];
+
+    function getCMSFields() {
+
+        $fields = parent::getCMSFields();
+
+        $uploadField = new UploadField(
+            'Image',
+            'Image'
+        );
+
+        $fields->addFieldToTab(
+            'Root.Main',
+            $uploadField
+        );
+
+        return $fields;
+    }
+}
+------
+<?php
+
+use SilverStripe\AssetAdmin\Forms\UploadField;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Assets\File;
+use SilverStripe\Assets\Image;
+
+
+class Food extends DataObject
+{
+    private static $db = [
+        'Name' => 'Varchar',
+    ];
+
+    private static $has_one = [
+        'File' => File::class,
+    ];
+
+    function getCMSFields() {
+
+        $fields = parent::getCMSFields();
+
+        $uploadField = new UploadField(
+            Image::class,
+            Image::class
+        );
+
+        $fields->addFieldToTab(
+            'Root.Main',
+            $uploadField
+        );
+
+        return $fields;
+    }
+}


### PR DESCRIPTION
Add ability for upgrader to display warnings for ambiguous class renames with the `renameWarnings` field from the `yaml` config. Users can also review and approve/reject renames manually by adding the `--prompt` flag to the `upgrade` command.

# Parent issue
* https://github.com/silverstripe/silverstripe-upgrader/issues/135