### PR TITLE
MINOR Don't add PHP constructs (e.g. integer) to the use statement

### DIFF
--- a/src/UpgradeRule/PHP/Visitor/ClassQualifierVisitor.php
+++ b/src/UpgradeRule/PHP/Visitor/ClassQualifierVisitor.php
@@ -36,7 +36,7 @@ class ClassQualifierVisitor extends NameResolver
         'callable',
         'iterable',
         'resource',
-        'NULL',
+        'null',
     ];
 
     /**
@@ -137,7 +137,7 @@ class ClassQualifierVisitor extends NameResolver
             // If this class is declared in this file, then don't alias,
             // as it will continue to work when applied to the same namespace
             // Classes declared in other files will, however, need a `use` alias.
-            if (!in_array($name, $this->specialNames) && !in_array($name, $this->fileClasses)) {
+            if (!in_array(strtolower($name), $this->specialNames) && !in_array($name, $this->fileClasses)) {
                 $this->newAliases[$name] = $name;
             }
         }

--- a/src/UpgradeRule/PHP/Visitor/ClassQualifierVisitor.php
+++ b/src/UpgradeRule/PHP/Visitor/ClassQualifierVisitor.php
@@ -24,7 +24,19 @@ class ClassQualifierVisitor extends NameResolver
     protected $specialNames = [
         'self',
         'parent',
-        'static'
+        'static',
+        'bool',
+        'boolean',
+        'integer',
+        'float',
+        'double',
+        'string',
+        'array',
+        'object',
+        'callable',
+        'iterable',
+        'resource',
+        'NULL',
     ];
 
     /**

--- a/tests/UpgradeRule/PHP/AddNamespaceTest.php
+++ b/tests/UpgradeRule/PHP/AddNamespaceTest.php
@@ -146,4 +146,42 @@ class AddNamespaceTest extends TestCase
         $this->assertFalse($changeset->hasWarnings($file4->getPath()));
         $this->assertEquals($output4, $generated4);
     }
+
+    /**
+     * Test applying namespaces to a file using scalar parameter type and return types.
+     */
+    public function testNamespaceUseStatement()
+    {
+        list($parameters, $input1, $output1) =
+            $this->loadFixture(__DIR__ .'/fixtures/add-namespace-use-statement.testfixture');
+
+        // Build mock collection
+        $code = new MockCodeCollection([
+            'dir/test1.php' => $input1,
+        ]);
+        $file1 = $code->itemByPath('dir/test1.php');
+
+        // Add spec to rule
+        $namespacer = new AddNamespaceRule();
+        $namespacer
+            ->withParameters($parameters)
+            ->withRoot('');
+
+        // Test that pre-post hooks detect namespaced classes
+        $changeset = new CodeChangeSet();
+        $namespacer->beforeUpgradeCollection($code, $changeset);
+        $this->assertEquals(
+            ['RenamedInterface'],
+            $namespacer->getClassesInNamespace('Upgrader\\NewNamespace')
+        );
+
+
+        // Check loading namespace from config
+        $this->assertEquals('Upgrader\\NewNamespace', $namespacer->getNamespaceForFile($file1));
+
+        // Test upgrading file1
+        $generated1 = $namespacer->upgradeFile($input1, $file1, $changeset);
+        $this->assertFalse($changeset->hasWarnings($file1->getPath()));
+        $this->assertEquals($output1, $generated1);
+    }
 }

--- a/tests/UpgradeRule/PHP/AddNamespaceTest.php
+++ b/tests/UpgradeRule/PHP/AddNamespaceTest.php
@@ -152,12 +152,12 @@ class AddNamespaceTest extends TestCase
      */
     public function testNamespaceUseStatement()
     {
-        list($parameters, $input1, $output1) =
+        list($parameters, $input, $output) =
             $this->loadFixture(__DIR__ .'/fixtures/add-namespace-use-statement.testfixture');
 
         // Build mock collection
         $code = new MockCodeCollection([
-            'dir/test1.php' => $input1,
+            'dir/test1.php' => $input,
         ]);
         $file1 = $code->itemByPath('dir/test1.php');
 
@@ -180,8 +180,8 @@ class AddNamespaceTest extends TestCase
         $this->assertEquals('Upgrader\\NewNamespace', $namespacer->getNamespaceForFile($file1));
 
         // Test upgrading file1
-        $generated1 = $namespacer->upgradeFile($input1, $file1, $changeset);
+        $generated1 = $namespacer->upgradeFile($input, $file1, $changeset);
         $this->assertFalse($changeset->hasWarnings($file1->getPath()));
-        $this->assertEquals($output1, $generated1);
+        $this->assertEquals($output, $generated1);
     }
 }

--- a/tests/UpgradeRule/PHP/fixtures/add-namespace-use-statement.testfixture
+++ b/tests/UpgradeRule/PHP/fixtures/add-namespace-use-statement.testfixture
@@ -23,6 +23,8 @@ interface RenamedInterface extends A, B {
 
     public function foo6(callable $hello, resource $bar): iterable;
 
+    public function foo7(oBjEcT $hello): aRrAy;
+
 }
 
 ------
@@ -48,5 +50,7 @@ interface RenamedInterface extends A, B {
     public function foo5(object $hello): array;
 
     public function foo6(callable $hello, resource $bar): iterable;
+
+    public function foo7(oBjEcT $hello): aRrAy;
 
 }

--- a/tests/UpgradeRule/PHP/fixtures/add-namespace-use-statement.testfixture
+++ b/tests/UpgradeRule/PHP/fixtures/add-namespace-use-statement.testfixture
@@ -1,0 +1,52 @@
+{
+    "add-namespace": [
+        {
+            "namespace": "Upgrader\\NewNamespace",
+            "path": "/dir"
+        }
+    ]
+}
+------
+<?php
+
+interface RenamedInterface extends A, B {
+
+    public function foo() : bool;
+
+    public function foo2($hello = NULL): integer;
+
+    public function foo3(string $hello, Acme $bar): boolean;
+
+    public function foo4(float $hello): double;
+
+    public function foo5(object $hello): array;
+
+    public function foo6(callable $hello, resource $bar): iterable;
+
+}
+
+------
+<?php
+
+namespace Upgrader\NewNamespace;
+
+use A;
+use B;
+use Acme;
+
+
+interface RenamedInterface extends A, B {
+
+    public function foo() : bool;
+
+    public function foo2($hello = NULL): integer;
+
+    public function foo3(string $hello, Acme $bar): boolean;
+
+    public function foo4(float $hello): double;
+
+    public function foo5(object $hello): array;
+
+    public function foo6(callable $hello, resource $bar): iterable;
+
+}


### PR DESCRIPTION
Fixing #150

This is not valid php.
```php
<?php
use integer;
use string;

function intToString(integer $val): string
{
    return (string)$val;
}
```

This PR simply adds PHP types to the list of words that should be ignored when adding `use` statements. 

