### PR TITLE
Add ability to update the autoload config in composer.json when calling the add-namespace command

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ upgrade-code add-namespace "My\Namespace" ./mysite/code/SomeCode.php --write -vv
 * Note that it's important to either quote or double-escape slashes in the namespace.
 * If you want to just do a dry-run, skip the `--write` param.
 * If you have multiple namespace levels you can add the `--recursive` or `-r` param to also update those levels.
-* If your filepath follows PSR-4 you can add the `--psr4` or `-p` param with the recursive param to auto-complete namespaces in child directories. The `--autoload` and `--autoload-dev` parameter can be use to quickly configure autoload in your `composer.json` file
+* If your filepath follows PSR-4 you can add the `--psr4` or `-p` param with the recursive param to auto-complete namespaces in child directories. The `--autoload` and `--autoload-dev` parameter can be used to quickly configure autoload in your `composer.json` file.
 
 This will namespace the class file SomeCode.php, and add the mapping to the `./.upgrader.yml` file in your project.
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ performed beforehand.
 You can run the below to add namespace to any class
 
 ```bash
-upgrade-code add-namespace <namespace> <filepath> [--root-dir=<dir>] [--write] [--recursive] [--psr4] [-vvv]
+upgrade-code add-namespace <namespace> <filepath> [--root-dir=<dir>] [--write] [--recursive] [--psr4] [-vvv] [--autoload] [--autoload-dev]
 ```
 
 Example:
@@ -106,8 +106,7 @@ upgrade-code add-namespace "My\Namespace" ./mysite/code/SomeCode.php --write -vv
 * Note that it's important to either quote or double-escape slashes in the namespace.
 * If you want to just do a dry-run, skip the `--write` param.
 * If you have multiple namespace levels you can add the `--recursive` or `-r` param to also update those levels.
-* If your filepath follows PSR-4 you can add the `--psr4` or `-p` param with the recursive param to auto-complete 
-namespaces in child directories.
+* If your filepath follows PSR-4 you can add the `--psr4` or `-p` param with the recursive param to auto-complete namespaces in child directories. The `--autoload` and `--autoload-dev` parameter can be use to quickly configure autoload in your `composer.json` file
 
 This will namespace the class file SomeCode.php, and add the mapping to the `./.upgrader.yml` file in your project.
 

--- a/src/CodeCollection/DiskCollection.php
+++ b/src/CodeCollection/DiskCollection.php
@@ -55,7 +55,7 @@ class DiskCollection implements CollectionInterface
     }
 
     /**
-     * Returns an iterator, yieldig all ItemInterface items in this collectinn
+     * Returns an iterator, yielding all ItemInterface items in this collection
      *
      * @return Iterator
      */

--- a/src/Composer/ComposerFile.php
+++ b/src/Composer/ComposerFile.php
@@ -157,7 +157,7 @@ class ComposerFile extends DiskItem
         // Build our propose new output
         $jsonData = $this->composerJson;
         $jsonData['require'] = $dependencies;
-        $upgradedContent = $this->encode($jsonData);
+        $upgradedContent = self::encode($jsonData);
 
         // Finally get our diff
         $change = new CodeChangeSet();
@@ -173,10 +173,10 @@ class ComposerFile extends DiskItem
      * @param array $json
      * @return string
      */
-    private function encode(array $json): string
+    public static function encode(array $json): string
     {
         // Recast some keys as object to avoid them being outputted as empty arrays in the JSON.
-        $keys = ['require', 'require-dev', 'extra', 'config'];
+        $keys = ['require', 'require-dev', 'extra', 'config', 'autoload', 'autoload-dev'];
         foreach ($keys as $key) {
             if (isset($json[$key])) {
                 $json[$key] = (object)$json[$key];

--- a/src/Util/AddAutoloadEntry.php
+++ b/src/Util/AddAutoloadEntry.php
@@ -29,7 +29,7 @@ class AddAutoloadEntry
      * @param string $rootPath Root of the project or module where the composer file is.
      * @param string $filePath Path where namespace are to be added.
      * @param string $namespace Namespace of the file.
-     * @param bool $devPath Whatever this is a dev autoload entry or a regular entry.
+     * @param bool $devPath Whether this is a dev autoload entry or a regular entry.
      */
     public function __construct(string $rootPath, string $filePath, string $namespace, bool $devPath)
     {
@@ -40,7 +40,7 @@ class AddAutoloadEntry
     }
 
     /**
-     * Update a composer file to include a PSR-4 auto load entry.
+     * Update a composer file to include a PSR-4 autoload entry.
      * @param CollectionInterface $code
      * @throws InvalidArgumentException if no composer file is present in the provided code collection.
      * @return CodeChangeSet

--- a/src/Util/AddAutoloadEntry.php
+++ b/src/Util/AddAutoloadEntry.php
@@ -1,0 +1,92 @@
+<?php
+namespace SilverStripe\Upgrader\Util;
+
+use SilverStripe\Upgrader\CodeCollection\CodeChangeSet;
+use SilverStripe\Upgrader\CodeCollection\CollectionInterface;
+use SilverStripe\Upgrader\Composer\ComposerFile;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * Class AddAutoloadEntry
+ */
+class AddAutoloadEntry
+{
+    /** @var string $rootPath */
+    private $rootPath;
+
+    /** @var string $filePath */
+    private $filePath;
+
+    /** @var string $namespace */
+    private $namespace;
+
+    /** @var bool $devPath */
+    private $devPath;
+
+    /**
+     *
+     * @param string $rootPath Root of the project or module where the composer file is.
+     * @param string $filePath Path where namespace are to be added.
+     * @param string $namespace Namespace of the file.
+     * @param bool $devPath Whatever this is a dev autoload entry or a regular entry.
+     */
+    public function __construct(string $rootPath, string $filePath, string $namespace, bool $devPath)
+    {
+        $this->rootPath = $rootPath;
+        $this->filePath = $filePath;
+        $this->namespace = rtrim($namespace, '\\') . '\\';
+        $this->devPath = $devPath;
+    }
+
+    /**
+     * Update a composer file to include a PSR-4 auto load entry.
+     * @param CollectionInterface $code
+     * @throws InvalidArgumentException if no composer file is present in the provided code collection.
+     * @return CodeChangeSet
+     */
+    public function upgrade(CollectionInterface $code): CodeChangeSet
+    {
+        $jsonStr = $code->itemByPath('composer.json')->getContents();
+        $json = json_decode($jsonStr, true);
+        $json = $this->addAutoloadKey($json);
+        return $this->toChangeSet($json, $jsonStr);
+    }
+
+    /**
+     * Add an autoload key to a composer json array
+     * @param array $json
+     * @return array
+     */
+    private function addAutoloadKey(array $json): array
+    {
+        $key = $this->devPath ? 'autoload-dev' : 'autoload';
+        if (!isset($json[$key])) {
+            $json[$key] = [];
+        }
+
+        if (!isset($json[$key]['psr4'])) {
+            $json[$key]['psr4'] = [];
+        }
+
+
+        $fs = new Filesystem();
+        $path = $fs->makePathRelative($this->filePath, $this->rootPath);
+        $json[$key]['psr4'][$this->namespace] = $path;
+
+        return $json;
+    }
+
+    /**
+     * Save the composer json array to a CodeChangeSet
+     * @param array $json
+     * @return CodeChangeSet
+     */
+    private function toChangeSet(array $json, string $original): CodeChangeSet
+    {
+        $jsonString = ComposerFile::encode($json);
+        $changes = new CodeChangeSet();
+        $changes->addFileChange('composer.json', $jsonString, $original);
+        return $changes;
+    }
+}

--- a/tests/Composer/ComposerFileTest.php
+++ b/tests/Composer/ComposerFileTest.php
@@ -132,4 +132,32 @@ EOF
         $this->assertEquals($diff->newContents($schema->getFullPath()), $expectedContent);
         $this->assertEquals($diff->oldContents($schema->getFullPath()), $initialContent);
     }
+
+    public function testEncode()
+    {
+        $data = [
+            'require' => [],
+            'require-dev' => [],
+            'extra' => [],
+            'config' => [],
+            'autoload' => [],
+            'autoload-dev' => [],
+            'repositories' => []
+        ];
+
+        $jsonStr = ComposerFile::encode($data);
+        $expected = <<<JSON
+{
+    "require": {},
+    "require-dev": {},
+    "extra": {},
+    "config": {},
+    "autoload": {},
+    "autoload-dev": {},
+    "repositories": []
+}
+JSON;
+
+        $this->assertEquals($expected, $jsonStr);
+    }
 }

--- a/tests/Util/AddAutoloadEntryTest.php
+++ b/tests/Util/AddAutoloadEntryTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace SilverStripe\Upgrader\Tests\Util;
+
+use PHPUnit\Framework\TestCase;
+use org\bovigo\vfs\vfsStream;
+use SilverStripe\Upgrader\CodeCollection\DiskCollection;
+use SilverStripe\Upgrader\Util\AddAutoloadEntry;
+
+class AddAutoloadEntryTest extends TestCase
+{
+    private $jsonStr = <<<JSON
+{
+    "name": "vendor-name/test-project",
+    "require": {},
+    "prefer-stable": true,
+    "minimum-stability": "dev"
+}
+JSON;
+
+
+    /**
+     * @internal checkPrerequisites doesn't have an output. The main thing we care about is that it should throw
+     * exceptions.
+     */
+    public function testUpgrade()
+    {
+        // Initial setup
+        $root = vfsStream::setup('ss_project_root', null, [
+            'composer.json' => $this->jsonStr
+        ]);
+        $code = new DiskCollection($root->url());
+
+        // Apply basic namespace
+        $autoload = new AddAutoloadEntry(
+            $root->url(),
+            $root->url() . '/mysite/code',
+            'VendorName\\ProjectTest',
+            false
+        );
+        $changeSet = $autoload->upgrade($code);
+        $code->applyChanges($changeSet);
+        $json = json_decode($code->itemByPath('composer.json')->getContents(), true);
+        $this->assertEquals(
+            ['psr4' => ['VendorName\\ProjectTest\\' => 'mysite/code/']],
+            $json['autoload']
+        );
+
+        // Apply dev namespace
+        $autoload = new AddAutoloadEntry(
+            $root->url(),
+            $root->url() . '/mysite/tests',
+            'VendorName\\ProjectTest\\Tests',
+            true
+        );
+        $changeSet = $autoload->upgrade($code);
+        $code->applyChanges($changeSet);
+        $json = json_decode($code->itemByPath('composer.json')->getContents(), true);
+        $this->assertEquals(
+            ['psr4' => ['VendorName\\ProjectTest\\' => 'mysite/code/']],
+            $json['autoload']
+        );
+        $this->assertEquals(
+            ['psr4' => ['VendorName\\ProjectTest\\Tests\\' => 'mysite/tests/']],
+            $json['autoload-dev']
+        );
+
+        // Apply additional namespace
+        $autoload = new AddAutoloadEntry(
+            $root->url(),
+            $root->url() . '/submodule/code',
+            'VendorName\\SubModule',
+            false
+        );
+        $changeSet = $autoload->upgrade($code);
+        $code->applyChanges($changeSet);
+        $json = json_decode($code->itemByPath('composer.json')->getContents(), true);
+        $this->assertEquals(
+            ['psr4' => [
+                'VendorName\\ProjectTest\\' => 'mysite/code/',
+                'VendorName\\SubModule\\' => 'submodule/code/'
+            ]],
+            $json['autoload']
+        );
+        $this->assertEquals(
+            ['psr4' => ['VendorName\\ProjectTest\\Tests\\' => 'mysite/tests/']],
+            $json['autoload-dev']
+        );
+    }
+}


### PR DESCRIPTION
Added a `--autoload` and `--autoload-dev` flag to the add-namespace command. When enable, a matching psr4 autoload entry will be added to the composer.json file.

# Parent issue
* #85 