### PR TITLE
Update ClassToTraitVisitor to ignore classes without extends statement.

### DIFF
--- a/src/UpgradeRule/PHP/Visitor/ClassToTraitVisitor.php
+++ b/src/UpgradeRule/PHP/Visitor/ClassToTraitVisitor.php
@@ -43,7 +43,7 @@ class ClassToTraitVisitor implements NodeVisitor
 
     public function enterNode(Node $node)
     {
-        if ($node instanceof Class_) {
+        if ($node instanceof Class_ && $node->extends) {
             $extends = $node->extends;
             $extendsName = $this->getNodeName($extends);
 

--- a/tests/UpgradeRule/PHP/Visitor/ClassToTraitTest.php
+++ b/tests/UpgradeRule/PHP/Visitor/ClassToTraitTest.php
@@ -45,4 +45,38 @@ class ClassToTraitTest extends BaseVisitorTest
 
         $this->assertEquals($generated, $expected);
     }
+
+    /**
+     * @runInSeparateProcess
+     * @throws \Exception
+     */
+    public function testReplaceClassWithTraitsWithoutExtends()
+    {
+        list($parameters, $input, $expected) =
+            $this->loadFixture(__DIR__ . '/../fixtures/class-to-traits-no-extends.testfixture');
+
+        $classToTraits = [
+            'SS_Object' => [
+                'SilverStripe\Core\Extensible'=> 'Extensible',
+                'SilverStripe\Core\Injector\Injectable'=> 'Injectable',
+                'SilverStripe\Core\Config\Configurable'=> 'Configurable'
+            ],
+            'Object' => [
+                'SilverStripe\Core\Extensible'=> 'Extensible',
+                'SilverStripe\Core\Injector\Injectable'=> 'Injectable',
+                'SilverStripe\Core\Config\Configurable'=> 'Configurable'
+            ]
+        ];
+
+        $code = new MockCodeCollection([
+            'dir/test.php' => $input,
+        ]);
+        $classToTraitRule = new ClassToTraitRule($classToTraits);
+        $changeset = new CodeChangeSet();
+        $classToTraitRule->beforeUpgradeCollection($code, $changeset);
+        $file = $code->itemByPath('dir/test.php');
+        $generated = $classToTraitRule->upgradeFile($input, $file, $changeset);
+
+        $this->assertEquals($generated, $expected);
+    }
 }

--- a/tests/UpgradeRule/PHP/fixtures/class-to-traits-no-extends.testfixture
+++ b/tests/UpgradeRule/PHP/fixtures/class-to-traits-no-extends.testfixture
@@ -1,0 +1,21 @@
+{
+}
+------
+<?php
+
+namespace Foo\View;
+
+class MyClass
+{
+    public $ID;
+}
+
+------
+<?php
+
+namespace Foo\View;
+
+class MyClass
+{
+    public $ID;
+}


### PR DESCRIPTION
`ClassToTraitVisitor` was always trying to read the extends statement of classes. This cause classes without an extends statement to fail.

# Parent issue
* https://github.com/silverstripe/silverstripe-upgrader/issues/178