### PR TITLE
Add an upgrader for PHPUnit 8 tests

### DIFF
--- a/src/Console/UpgradeCommand.php
+++ b/src/Console/UpgradeCommand.php
@@ -9,6 +9,7 @@ use SilverStripe\Upgrader\Upgrader;
 use SilverStripe\Upgrader\UpgradeRule\PHP\ClassToTraitRule;
 use SilverStripe\Upgrader\UpgradeRule\PHP\RenameClasses;
 use SilverStripe\Upgrader\UpgradeRule\PHP\RenameTranslateKeys;
+use SilverStripe\Upgrader\UpgradeRule\PHP\UpgradePhpUnitTests;
 use SilverStripe\Upgrader\UpgradeRule\SS\RenameTemplateLangKeys;
 use SilverStripe\Upgrader\UpgradeRule\YML\RenameYMLLangKeys;
 use SilverStripe\Upgrader\UpgradeRule\YML\UpdateConfigClasses;
@@ -130,6 +131,7 @@ class UpgradeCommand extends AbstractCommand implements AutomatedCommand
         $ruleObjects = [];
         if (in_array('code', $rules)) {
             $ruleObjects[] = new RenameClasses($input->getOption('prompt'), $this, $input, $output);
+            $ruleObjects[] = new UpgradePhpUnitTests();
         }
         if (in_array('config', $rules)) {
             $ruleObjects[] = new UpdateConfigClasses();

--- a/src/UpgradeRule/PHP/UpgradePhpUnitTests.php
+++ b/src/UpgradeRule/PHP/UpgradePhpUnitTests.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace SilverStripe\Upgrader\UpgradeRule\PHP;
+
+use SilverStripe\Upgrader\CodeCollection\CodeChangeSet;
+use SilverStripe\Upgrader\CodeCollection\ItemInterface;
+use SilverStripe\Upgrader\UpgradeRule\PHP\Visitor\PhpUnitVisitor;
+use SilverStripe\Upgrader\Util\MutableSource;
+
+class UpgradePhpUnitTests extends PHPUpgradeRule
+{
+    public function appliesTo(ItemInterface $file)
+    {
+        // php file that extend TestCase
+        return 'php' === $file->getExtension();
+    }
+    /**
+     * @inheritDoc
+     */
+    public function upgradeFile($contents, ItemInterface $file, CodeChangeSet $changeset)
+    {
+        if (!$this->appliesTo($file)) {
+            return $contents;
+        }
+        $source = new MutableSource($contents);
+
+        $tree = $source->getAst();
+        $this->transformWithVisitors($tree, [
+            new PhpUnitVisitor($source),
+        ]);
+
+        return $source->getModifiedString();
+    }
+}

--- a/src/UpgradeRule/PHP/UpgradePhpUnitTests.php
+++ b/src/UpgradeRule/PHP/UpgradePhpUnitTests.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Upgrader\UpgradeRule\PHP;
 
+use PhpParser\ParserFactory;
 use SilverStripe\Upgrader\CodeCollection\CodeChangeSet;
 use SilverStripe\Upgrader\CodeCollection\ItemInterface;
 use SilverStripe\Upgrader\UpgradeRule\PHP\Visitor\PhpUnitVisitor;
@@ -22,7 +23,7 @@ class UpgradePhpUnitTests extends PHPUpgradeRule
         if (!$this->appliesTo($file)) {
             return $contents;
         }
-        $source = new MutableSource($contents);
+        $source = new MutableSource($contents, ParserFactory::PREFER_PHP7);
 
         $tree = $source->getAst();
         $this->transformWithVisitors($tree, [

--- a/src/UpgradeRule/PHP/Visitor/PhpUnitVisitor.php
+++ b/src/UpgradeRule/PHP/Visitor/PhpUnitVisitor.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace SilverStripe\Upgrader\UpgradeRule\PHP\Visitor;
+
+use PhpParser\Comment\Doc;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\NodeVisitor;
+use SilverStripe\Upgrader\Util\MutableSource;
+
+class PhpUnitVisitor implements NodeVisitor
+{
+    use VisitorTrait;
+
+    /**
+     * @var MutableSource
+     */
+    protected $source;
+
+    public function __construct(MutableSource $source)
+    {
+        $this->source = $source;
+    }
+
+    /**
+     * @param $node
+     * @param int $visibility
+     * @return mixed
+     */
+    protected static function changeVisibility($node, $visibility = Class_::MODIFIER_PROTECTED)
+    {
+        // remove other flags
+        if ($visibility != Class_::MODIFIER_PRIVATE) {
+            $node->flags = $node->flags & (~ Class_::MODIFIER_PRIVATE);
+        }
+        if ($visibility != Class_::MODIFIER_PROTECTED) {
+            $node->flags = $node->flags & (~ Class_::MODIFIER_PROTECTED);
+        }
+        if ($visibility != Class_::MODIFIER_PUBLIC) {
+            $node->flags = $node->flags & (~ Class_::MODIFIER_PUBLIC);
+        }
+
+        // add our flag
+        $node->flags |= $visibility;
+
+        return $node;
+    }
+
+    protected static function makeStatic($node)
+    {
+        $node->flags |= Class_::MODIFIER_STATIC;
+        return $node;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function beforeTraverse(array $nodes)
+    {
+        // TODO: Implement beforeTraverse() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function enterNode(Node $node)
+    {
+        if ($node instanceof Node\Stmt\ClassMethod) {
+            switch (strtolower($node->name)) {
+                case 'setup':
+                    $this->source->replaceNode($node, static::changeVisibility($node));
+                    break;
+                case 'teardown':
+                    $this->source->replaceNode($node, static::changeVisibility($node));
+                    break;
+                case 'setUpBeforeClass':
+                    $node = static::changeVisibility($node, Class_::MODIFIER_PUBLIC);
+                    $node = static::makeStatic($node);
+                    $this->source->replaceNode($node, $node);
+                    break;
+                case 'tearDownAfterClass':
+                    $node = static::changeVisibility($node, Class_::MODIFIER_PUBLIC);
+                    $node = static::makeStatic($node);
+                    $this->source->replaceNode($node, $node);
+                    break;
+            }
+            if ($docBlock = $node->getDocComment()) {
+                $lines = array_reverse(explode("\n", $docBlock->getText()));
+                $newComment = [];
+                $update = false;
+                foreach ($lines as $line) {
+                    $rawLine = trim($line, "* \t\n\r\0\x0B");
+                    if ($rawLine && preg_match('/^@([a-z]+)\s+(.*)/i', $rawLine, $matches)) {
+                        $annotation = $matches[1];
+                        $argument = $matches[2];
+                        if (in_array($annotation, ['expectedException', 'expectedExceptionCode', 'expectedExceptionMessage', 'expectedExceptionMessageRegExp'])) {
+                            $update = true;
+                            switch ($annotation) {
+                                case 'expectedException':
+                                    $call = new Node\Expr\MethodCall(
+                                        new Node\Expr\Variable('this'),
+                                        'expectedException',
+                                        [
+                                            new Node\Arg(new Node\Expr\ClassConstFetch(
+                                                new Node\Name($argument),
+                                                'class'
+                                            )),
+                                        ]
+                                    );
+                                    array_unshift($node->stmts, $call);
+                                    break;
+                                case 'expectedExceptionMessageRegExp':
+                                    $call = new Node\Expr\MethodCall(
+                                        new Node\Expr\Variable('this'),
+                                        'expectExceptionMessageMatches',
+                                        [
+                                            new Node\Arg(new Node\Scalar\String_($argument)),
+                                        ]
+                                    );
+                                    array_unshift($node->stmts, $call);
+                                    break;
+                                case 'expectedExceptionCode':
+                                    $call = new Node\Expr\MethodCall(
+                                        new Node\Expr\Variable('this'),
+                                        'expectedExceptionCode',
+                                        [
+                                            new Node\Arg(new Node\Scalar\String_($argument)),
+                                        ]
+                                    );
+                                    array_unshift($node->stmts, $call);
+                                    break;
+                                case 'expectedExceptionMessage':
+                                    $call = new Node\Expr\MethodCall(
+                                        new Node\Expr\Variable('this'),
+                                        'expectedExceptionMessage',
+                                        [
+                                            new Node\Arg(new Node\Scalar\String_($argument)),
+                                        ]
+                                    );
+                                    array_unshift($node->stmts, $call);
+                                    break;
+                            }
+                        } else {
+                            $newComment[] = $line;
+                        }
+                    } else {
+                        $newComment[] = $line;
+                    }
+                }
+                if ($update) {
+                    if (count($newComment) === 2) {
+                        // empty comment
+                        $comment = new Doc('', $docBlock->getLine(), $docBlock->getFilePos());
+                    } else {
+                        $comment = new Doc(implode("\n", array_reverse($newComment)), $docBlock->getLine(), $docBlock->getFilePos());
+                    }
+                    $node->setDocComment($comment);
+                    $this->source->replaceNode($node, $node);
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function leaveNode(Node $node)
+    {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function afterTraverse(array $nodes)
+    {
+        // TODO: Implement afterTraverse() method.
+    }
+}

--- a/src/UpgradeRule/PHP/Visitor/PhpUnitVisitor.php
+++ b/src/UpgradeRule/PHP/Visitor/PhpUnitVisitor.php
@@ -67,7 +67,7 @@ class PhpUnitVisitor implements NodeVisitor
     {
         $changed = false;
         if ($node instanceof Node\Stmt\ClassMethod) {
-            $oldNode = $node;
+            $oldNode = clone $node;
             switch (strtolower($node->name)) {
                 case 'setup':
                 case 'teardown':

--- a/src/UpgradeRule/PHP/Visitor/PhpUnitVisitor.php
+++ b/src/UpgradeRule/PHP/Visitor/PhpUnitVisitor.php
@@ -101,7 +101,7 @@ class PhpUnitVisitor implements NodeVisitor
                             case 'expectedException':
                                 $call = new Node\Expr\MethodCall(
                                     new Node\Expr\Variable('this'),
-                                    'expectedException',
+                                    'expectException',
                                     [
                                         new Node\Arg(new Node\Expr\ClassConstFetch(
                                             new Node\Name($argument),
@@ -126,7 +126,7 @@ class PhpUnitVisitor implements NodeVisitor
                             case 'expectedExceptionCode':
                                 $call = new Node\Expr\MethodCall(
                                     new Node\Expr\Variable('this'),
-                                    'expectedExceptionCode',
+                                    'expectExceptionCode',
                                     [
                                         new Node\Arg(new Node\Scalar\String_($argument)),
                                     ]
@@ -137,7 +137,7 @@ class PhpUnitVisitor implements NodeVisitor
                             case 'expectedExceptionMessage':
                                 $call = new Node\Expr\MethodCall(
                                     new Node\Expr\Variable('this'),
-                                    'expectedExceptionMessage',
+                                    'expectExceptionMessage',
                                     [
                                         new Node\Arg(new Node\Scalar\String_($argument)),
                                     ]

--- a/src/UpgradeRule/PHP/Visitor/PhpUnitVisitor.php
+++ b/src/UpgradeRule/PHP/Visitor/PhpUnitVisitor.php
@@ -67,6 +67,7 @@ class PhpUnitVisitor implements NodeVisitor
     {
         $changed = false;
         if ($node instanceof Node\Stmt\ClassMethod) {
+            $oldNode = $node;
             switch (strtolower($node->name)) {
                 case 'setup':
                 case 'teardown':
@@ -171,7 +172,7 @@ class PhpUnitVisitor implements NodeVisitor
                 }
             }
             if ($changed) {
-                $this->source->replaceNode($node, $node);
+                $this->source->replaceNode($oldNode, $node);
             }
         }
         return null;

--- a/src/Util/MutableSource.php
+++ b/src/Util/MutableSource.php
@@ -33,7 +33,7 @@ class MutableSource
      */
     private $prettyPrinter = null;
 
-    public function __construct($source)
+    public function __construct($source, $kind = ParserFactory::PREFER_PHP5)
     {
         $this->source = new MutableString($source);
         $this->prettyPrinter = new PrettyPrinter\Standard();
@@ -41,7 +41,7 @@ class MutableSource
         $lexer = new Lexer\Emulative([
             'usedAttributes' => ['comments', 'startFilePos', 'endFilePos', 'startLine', 'endLine']
         ]);
-        $parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP5, $lexer);
+        $parser = (new ParserFactory())->create($kind, $lexer);
         $this->ast = $parser->parse($source);
     }
 

--- a/src/Util/MutableSource.php
+++ b/src/Util/MutableSource.php
@@ -280,9 +280,15 @@ class MutableSource
                 . "Check your Lexer usedAttributes option!");
         }
 
+        $start = $attributes['startFilePos'];
+        $docBlock = $node->getDocComment();
+        if ($docBlock) {
+            $start = $docBlock->getFilePos();
+        }
+
         return [
-            $attributes['startFilePos'],
-            $attributes['endFilePos'] - $attributes['startFilePos'] + 1,
+            $start,
+            $attributes['endFilePos'] - $start + 1,
         ];
     }
 }

--- a/src/Util/MutableString.php
+++ b/src/Util/MutableString.php
@@ -77,13 +77,25 @@ class MutableString
         return $this->string;
     }
 
+    protected static function indentString($string, $indent)
+    {
+        $lines = explode(PHP_EOL, $string);
+        return implode(PHP_EOL . $indent, $lines);
+    }
+
     public function getModifiedString()
     {
         $result = '';
         $startPos = 0;
         foreach ($this->getSortedModifications() as list($pos, $len, $newString)) {
             $result .= substr($this->string, $startPos, $pos - $startPos);
-            $result .= $newString;
+            // find the current indent size by finding the spaces since the last new line
+            $indent = false;
+            if (preg_match('/([[:blank:]]+)$/', $result, $matches)) {
+                $indent = $matches[1];
+            }
+            $indentedString = $indent ? static::indentString($newString, $indent) : $newString;
+            $result .= $indentedString;
             $startPos = $pos + $len;
         }
         $result .= substr($this->string, $startPos);

--- a/tests/UpgradeRule/PHP/fixtures/update-visibility.testfixture
+++ b/tests/UpgradeRule/PHP/fixtures/update-visibility.testfixture
@@ -46,9 +46,9 @@ class Animal extends Living
     private static $db = array('Name' => 'Varchar');
 
     protected function myMethod()
-{
-    echo "Hello, world!";
-}
+    {
+        echo "Hello, world!";
+    }
 
     public static $do_not_change_me = "foobar";
 }


### PR DESCRIPTION
This is a very early effort at upgrading PHPUnit tests for v8/v9 of PHPUnit.

Tasks:
- [x] Ensure that visibility of `setUp` and `tearDown` are `protected`
- [x] Ensure that visibility of `setUpBeforeClass` and `tearDownAfterClass` are `public`
- [x] Ensure that return type `void` is defined for `setUp*` and `tearDown*` methods
- [x] Ensure that `setUpBeforeClass` and `tearDownAfterClass` are `static`
- [x] Re-write deprecated annotations as method calls

Issues:

~~For this to work properly we need to run in PHP7 mode for parsing otherwise scalar return type hinting gets namespaced (eg: `protected function setUp() : void` becomes `protected function setUp() : SilverStripe\Control\Tests\void`) if we use PHP5 parsing mode.~~

~~I don't know if we want to release a new upgrader version for v4 that would parse in php7 mode by default?~~

It's pretty simple to just set the parser version on a per rule basis, so I've done that.

- [x] Code is written with indent level stripped
- [x] Code is written with all namespaces fully qualified
- [x] Doc comment is not being replaced, instead a new comment is being added